### PR TITLE
Features/raws :  Introduce Image Configuration Framework & Enhance Color Space Handling

### DIFF
--- a/.github/workflows/ubuntu_ninja.yml
+++ b/.github/workflows/ubuntu_ninja.yml
@@ -25,6 +25,15 @@ jobs:
             preset: debug-ninja-linux
 
     steps:
+
+      # ====================================================================
+      # Update and install build-essential (includes make, gcc, g++, etc.)
+      # ====================================================================
+      - name: Update
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential
+
       # ====================================================================
       # Checkout
       # ====================================================================
@@ -56,9 +65,6 @@ jobs:
       # ====================================================================
       - name: Install APT dependencies
         run: |
-          sudo apt update
-          sudo apt install -y build-essential
-
           sudo apt install -y libspdlog-dev 
           
           sudo apt install -y libcurl4-openssl-dev
@@ -185,7 +191,9 @@ jobs:
           --preset ${{ matrix.preset }} \
           -DBUILD_DESKTOP_UI:BOOL=ON \
           ${TESTS_FLAG} \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+          -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+          -DCMAKE_CXX_COMPILER=g++-14
+
         shell: bash
 
       # ====================================================================

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,6 +74,7 @@ set(CORE_SOURCES
 
     # Utils
     src/utils/image_conversion.cpp
+    src/utils/color_space_utils.cpp
 )
 
 # Verify sources exist

--- a/core/include/common/error_handling/core_error.h
+++ b/core/include/common/error_handling/core_error.h
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <cstdint>
 #include <format>
+#include <fmt/core.h>
 
 namespace CaptureMoment::Core {
 
@@ -247,6 +248,21 @@ struct std::formatter<CaptureMoment::Core::ErrorHandling::CoreError> : std::form
     auto format(const CaptureMoment::Core::ErrorHandling::CoreError code, FormatContext& ctx) const
     {
         return std::formatter<std::string_view>::format(
+            CaptureMoment::Core::ErrorHandling::to_string(code), ctx);
+    }
+};
+
+/**
+ * @brief fmt::formatter specialization for CoreError.
+ * @details Enables direct formatting with spdlog/fmt (e.g., "{}", CoreError::FileNotFound).
+ */
+template <>
+struct fmt::formatter<CaptureMoment::Core::ErrorHandling::CoreError>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(const CaptureMoment::Core::ErrorHandling::CoreError& code, FormatContext& ctx) const {
+        return fmt::formatter<std::string_view>::format(
             CaptureMoment::Core::ErrorHandling::to_string(code), ctx);
     }
 };

--- a/core/include/common/error_handling/core_error.h
+++ b/core/include/common/error_handling/core_error.h
@@ -10,6 +10,7 @@
 
 #include <string_view>
 #include <cstdint>
+#include <format>
 
 namespace CaptureMoment::Core {
 
@@ -234,3 +235,18 @@ enum class CoreErrorCategory : uint8_t {
 } // namespace ErrorHandling
 
 } // namespace CaptureMoment::Core
+
+/**
+ * @brief std::formatter specialization for CoreError.
+ * @details Enables direct formatting with spdlog/std::format (e.g., "{}", CoreError::FileNotFound).
+ */
+template <>
+struct std::formatter<CaptureMoment::Core::ErrorHandling::CoreError> : std::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(const CaptureMoment::Core::ErrorHandling::CoreError code, FormatContext& ctx) const
+    {
+        return std::formatter<std::string_view>::format(
+            CaptureMoment::Core::ErrorHandling::to_string(code), ctx);
+    }
+};

--- a/core/include/common/image_region.h
+++ b/core/include/common/image_region.h
@@ -123,6 +123,7 @@ struct ImageRegion {
         , m_width(w)
         , m_height(h)
         , m_channels(ch)
+        , m_format(PixelFormat::RGBA_F32) // Default format
     {}
 
     /**
@@ -142,6 +143,7 @@ struct ImageRegion {
         , m_width(w)
         , m_height(h)
         , m_channels(ch)
+        , m_format(PixelFormat::RGBA_F32) // Default format
     {}
 
     // ============================================================

--- a/core/include/common/pixel_format.h
+++ b/core/include/common/pixel_format.h
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <cstddef>  // Required for size_t
-#include <cstdint>  // Required for uint8_t
+#include <cstddef>
+#include <cstdint>
 
 namespace CaptureMoment::Core {
 
@@ -62,29 +62,6 @@ enum class PixelFormat : std::uint8_t {
      * - **Usage:** Common for image files that do not contain an alpha channel.
      */
     RGB_F32,
-
-    /**
-     * @brief 4-channel format: Red, Green, Blue, Alpha in 8-bit unsigned integer.
-     *     (BUGFIX: Original comment said 3-channel, corrected for RGBA).
-     *
-     * Each pixel is stored as 4 consecutive `uint8_t` values (0-255).
-     * - **Size per pixel:** 4 bytes (4 channels * 1 byte per uint8_t)
-     * - **Value range:** `[0, 255]` (corresponding to `[0.0f, 1.0f]` when normalized)
-     * - **Usage:** Standard format for image export to formats like PNG
-     *             where alpha is supported.
-     */
-    RGBA_U8,
-
-    /**
-     * @brief 3-channel format: Red, Green, Blue in 8-bit unsigned integer.
-     *
-     * Each pixel is stored as 3 consecutive `uint8_t` values (0-255).
-     * - **Size per pixel:** 3 bytes (3 channels * 1 byte per uint8_t)
-     * - **Value range:** `[0, 255]` (corresponding to `[0.0f, 1.0f]` when normalized)
-     * - **Usage:** Standard format for image export to formats like JPEG
-     *             where alpha is not supported and memory usage is a concern.
-     */
-    RGB_U8
 };
 
 /**
@@ -97,15 +74,11 @@ enum class PixelFormat : std::uint8_t {
 {
     switch(pf) {
     case PixelFormat::RGBA_F32:
-    case PixelFormat::RGBA_U8:
         return 4;
     case PixelFormat::RGB_F32:
-    case PixelFormat::RGB_U8:
         return 3;
     default:
-        // In C++23, one might use std::unreachable() here,
-        // but returning 0 is safer for robustness against bad casts.
-        return 0;
+        std::unreachable();
     }
 }
 
@@ -117,15 +90,7 @@ enum class PixelFormat : std::uint8_t {
  */
 [[nodiscard]] constexpr std::size_t getPixelSizeInBytes(PixelFormat fmt) noexcept
 {
-    // Cast explicitly to size_t to avoid signed/unsigned warnings
-    const std::size_t channels = static_cast<std::size_t>(getChannelCount(fmt));
-
-    if (fmt == PixelFormat::RGBA_F32 || fmt == PixelFormat::RGB_F32) {
-        return channels * sizeof(float);
-    } else {
-        // Assume U8 formats if not float (handles both RGB_U8 and RGBA_U8)
-        return channels * sizeof(std::uint8_t);
-    }
+    return static_cast<std::size_t>(getChannelCount(fmt)) * sizeof(float);
 }
 
 } // namespace Common

--- a/core/include/image_config/heic_settings.h
+++ b/core/include/image_config/heic_settings.h
@@ -1,0 +1,231 @@
+/**
+ * @file heic_settings.h
+ * @brief Input configuration settings for HEIF/HEIC/AVIF image loading via OIIO/libheif.
+ * @author CaptureMoment Team
+ * @date 2026
+ *
+ * This file provides a configuration system for HEIF family formats
+ * (HEIC based on HEVC/H.265, AVIF based on AV1) via OIIO/libheif.
+ *
+ * This struct is used exclusively by SourceManager for loading/reading.
+ * Output settings (compression, quality, format choice) are handled
+ * by the export module, where the user selects the target format.
+ *
+ * All parameters are runtime-configurable with sensible defaults.
+ *
+ * @note Currently OIIO's HEIF reader supports reading as RGB or RGBA, uint8 pixel values.
+ *       HDR (more than 8 bits) support is planned for future libheif versions.
+ *
+ * @note libheif >= 1.16 required for "oiio:reorient" configuration option.
+ * @note libheif >= 1.17 required for monochrome HEIC images.
+ *
+ * @see RawSettings For RAW-specific configuration.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace CaptureMoment::Core::ImageConfig {
+
+/**
+ * @brief Namespace for HEIF/HEIC/AVIF-specific configuration settings.
+ */
+namespace Heic {
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ENUMERATIONS FOR HEIF SETTINGS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * @enum AlphaMode
+ * @brief Controls how unassociated alpha channels are handled during reading.
+ *
+ * Some HEIF files contain unassociated alpha, meaning the alpha channel
+ * describes coverage but the color channels have not been pre-multiplied.
+ * This setting determines whether to premultiply color channels by alpha
+ * during loading, or leave them unassociated.
+ *
+ * @note The Core pipeline treats all channels identically (channel-agnostic).
+ *       Premultiplied alpha is the recommended default because it keeps
+ *       operations (brightness, contrast, etc.) consistent across all channels
+ *       without requiring special alpha handling in Halide kernels.
+ */
+enum class AlphaMode : std::uint8_t {
+    premultiply,       ///< Default OIIO behavior: premultiply color channels by alpha if unassociated.
+    unassociated       ///< Leave alpha unassociated. Preserve original color values without modification.
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HEIF SETTINGS STRUCTURE (INPUT ONLY)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * @struct HeicSettings
+ * @brief Input configuration for HEIF/HEIC/AVIF image loading via OIIO/libheif.
+ *
+ * This struct encapsulates all HEIF **input** parameters used by SourceManager
+ * when loading HEIF family files. Output settings (compression codec, quality,
+ * format selection) are handled by the export module and are NOT part of this struct.
+ *
+ * ## Architecture Notes
+ * - **Input only**: reorient, alpha_mode control how OIIO reads HEIF files.
+ * - **Output excluded**: compression, quality, format choice belong to the export module.
+ *   The user selects the output format at export time, not at load time.
+ * - HEIF files from smartphones (iPhone, Android) are the most common use case.
+ *
+ * ## Default Configuration Rationale
+ * - **reorient**: Enabled. HEIF files contain EXIF orientation metadata from smartphones.
+ *                 Reorientation ensures correct display without manual rotation.
+ * - **alpha_mode**: premultiply. Standard compositing convention, consistent with Core's
+ *                    channel-agnostic F32 pipeline. Avoids special alpha handling in kernels.
+ *
+ * ## OIIO Limitations
+ * - All pixel data is currently uint8. HDR support (10-bit, 12-bit) is planned.
+ * - Multi-image files are supported for reading, not yet for writing.
+ * - libheif >= 1.16 required for reorient option.
+ * - libheif >= 1.17 required for monochrome HEIC images.
+ *
+ * @note Thread-safe for read access. Write operations should be synchronized externally.
+ */
+struct HeicSettings {
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // INPUT SETTINGS (used by SourceManager)
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    /**
+     * @brief If nonzero, asks libheif to reorient images based on EXIF orientation.
+     *
+     * When enabled (default), libheif rotates/flips the image pixels to match
+     * the orientation indicated by the camera, and sets the "Orientation"
+     * metadata to 1 (meaning "no rotation needed"). The original orientation
+     * is preserved in "oiio:OriginalOrientation" metadata.
+     *
+     * When disabled, the pixels are left in their stored orientation and
+     * the "Orientation" metadata reflects the camera orientation.
+     *
+     * This is particularly important for HEIF files from smartphones, which
+     * almost always store orientation metadata (portrait/landscape).
+     *
+     * @note Requires libheif >= 1.16.
+     */
+    bool m_reorient{true};
+
+    /**
+     * @brief Controls how unassociated alpha is handled during reading.
+     *
+     * HEIF files can contain unassociated alpha (alpha describes pixel coverage
+     * but color channels are not pre-multiplied by alpha). The default OIIO
+     * behavior is to premultiply color channels by alpha. Setting this to
+     * unassociated preserves the original color values.
+     *
+     * For the Core's F32 processing pipeline, premultiplied alpha is the
+     * recommended default because the pipeline is channel-agnostic:
+     * all operations (brightness, contrast, shadows, etc.) treat all 4 channels
+     * identically. Premultiplied alpha ensures that operations on RGB channels
+     * remain consistent with the alpha channel without requiring special handling.
+     *
+     * @note Setting this to unassociated is only safe if the pipeline explicitly
+     *       excludes the alpha channel from processing operations.
+     */
+    AlphaMode m_alpha_mode{AlphaMode::premultiply};
+
+public:
+    /**
+     * @brief Checks if automatic reorientation is enabled.
+     * @return true if libheif will reorient images based on EXIF orientation.
+     */
+    [[nodiscard]] constexpr bool get_reorient() const noexcept { return m_reorient; }
+
+    /**
+     * @brief Enables or disables automatic reorientation.
+     * @param reorient true to reorient based on EXIF orientation (recommended).
+     * @note Requires libheif >= 1.16.
+     */
+    constexpr void set_reorient(bool reorient) noexcept { m_reorient = reorient; }
+
+    /**
+     * @brief Gets the reorient value as integer (for OIIO attribute).
+     * @return 1 if reorient enabled, 0 if disabled.
+     */
+    [[nodiscard]] constexpr int get_reorient_value() const noexcept {
+        return m_reorient ? 1 : 0;
+    }
+
+    /**
+     * @brief Gets the alpha handling mode.
+     * @return The current alpha mode.
+     */
+    [[nodiscard]] constexpr AlphaMode get_alpha_mode() const noexcept { return m_alpha_mode; }
+
+    /**
+     * @brief Sets the alpha handling mode.
+     * @param mode The alpha mode to use.
+     */
+    constexpr void set_alpha_mode(AlphaMode mode) noexcept { m_alpha_mode = mode; }
+
+    /**
+     * @brief Gets the unassociated alpha value as integer (for OIIO attribute).
+     * @return 1 if unassociated alpha should be preserved, 0 for premultiply (default).
+     */
+    [[nodiscard]] constexpr int get_unassociated_alpha_value() const noexcept {
+        return (m_alpha_mode == AlphaMode::unassociated) ? 1 : 0;
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // PRESET FACTORY METHODS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Creates a HeicSettings configured for maximum processing speed.
+     * @return HeicSettings with speed-optimized configuration.
+     *
+     * ## Configuration Rationale
+     * | Parameter     | Value           | Reason                                  |
+     * |---------------|-----------------|-----------------------------------------|
+     * | reorient      | false           | Skip pixel reorientation overhead       |
+     * | alpha_mode    | premultiply     | Standard convention, no extra work      |
+     *
+     * @note Use for quick preview loading or when speed is critical.
+     * @warning Image may appear rotated incorrectly if reorient is disabled.
+     */
+    [[nodiscard]] static constexpr HeicSettings fast_settings() noexcept {
+        HeicSettings settings;
+        settings.m_reorient = false;
+        settings.m_alpha_mode = AlphaMode::premultiply;
+        return settings;
+    }
+
+    /**
+     * @brief Creates a HeicSettings with default values.
+     * @return HeicSettings with recommended default configuration.
+     *
+     * ## Configuration Rationale
+     * | Parameter     | Value           | Reason                                  |
+     * |---------------|-----------------|-----------------------------------------|
+     * | reorient      | true            | Correct orientation from EXIF metadata  |
+     * | alpha_mode    | premultiply     | Consistent with channel-agnostic pipeline|
+     *
+     * @note This is the recommended configuration for all standard use cases.
+     */
+    [[nodiscard]] static constexpr HeicSettings default_settings() noexcept {
+        return HeicSettings{};
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // UTILITY METHODS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Resets all settings to their default values.
+     */
+    void reset_to_defaults() noexcept {
+        *this = HeicSettings{};
+    }
+};
+
+} // namespace Heic
+
+} // namespace CaptureMoment::Core::ImageConfig

--- a/core/include/image_config/image_config.h
+++ b/core/include/image_config/image_config.h
@@ -18,3 +18,12 @@
  */
 #include "image_config/raw_settings.h"
 
+
+// ============================================================
+// 2. Heic Data Structures
+// ============================================================
+
+/**
+ * @brief HeicSettings structure representing the unprocessed settings for HEIF/HEIC/AVIF image loading.
+ */
+#include "image_config/heic_settings.h"

--- a/core/include/image_config/image_config.h
+++ b/core/include/image_config/image_config.h
@@ -1,0 +1,20 @@
+/**
+ * @file image_config.h
+ * @brief Umbrella header for the ImageConfig module of the CaptureMoment Core Library.
+ 
+ *
+ * @author CaptureMoment Team
+ * @date 2026
+ */
+
+#pragma once
+
+// ============================================================
+// 1. Raw Data Structures
+// ============================================================
+
+/**
+ * @brief RawSettings structure representing the unprocessed settings for an image operation.
+ */
+#include "image_config/raw_settings.h"
+

--- a/core/include/image_config/raw_settings.h
+++ b/core/include/image_config/raw_settings.h
@@ -1,0 +1,890 @@
+/**
+ * @file raw_settings.h
+ * @brief Comprehensive RAW development settings with runtime configuration.
+ * @author CaptureMoment Team
+ * @date 2026
+ * This file provides a complete configuration system for RAW image development
+ * via OIIO/LibRaw. All parameters are runtime-configurable with sensible defaults.
+ * @note Uses magic_enum for enum - string conversion.
+ * @note All getters are constexpr and noexcept.
+ * @note All setters are noexcept.
+ */
+#pragma once
+#include <string>
+#include <array>
+#include <magic_enum/magic_enum.hpp>
+namespace CaptureMoment::Core::ImageConfig {
+
+/**
+ * @brief Namespace for RAW-specific configuration settings.
+ */
+namespace Raw {
+// ═══════════════════════════════════════════════════════════════════════════════
+// ENUMERATIONS FOR RAW SETTINGS
+// ═══════════════════════════════════════════════════════════════════════════════
+/**
+ * @enum HighlightMode
+ * @brief Controls how overexposed/clipped highlights are handled during RAW development.
+ * When sensor channels saturate at different levels, highlights can take on 
+ * unnatural color casts. The highlight mode determines how these clipped values
+ * are reconstructed or blended.
+ */
+enum class HighlightMode : std::uint8_t {
+    clip = 0,       ///< Clip all channels to maximum (default LibRaw behavior). Fast but may cause color shifts.
+    unclip = 1,     ///< Unclip: attempt to reconstruct clipped values. Better for slight overexposure.
+    blend = 2,      ///< Blend clipped areas with surrounding unclipped data. Natural-looking highlights.
+    rebuild = 3     ///< Reconstruct highlights using advanced algorithms. Best quality for heavily clipped areas.
+};
+
+/**
+ * @enum DemosaicAlgorithm
+ * @brief Demosaicing algorithms for converting Bayer pattern RAW data to RGB.
+ * Demosaicing is the process of interpolating missing color values from the
+ * Bayer filter pattern. Quality vs speed trade-offs exist between algorithms.
+ */
+enum class DemosaicAlgorithm : std::uint8_t {
+    linear,     ///< Simple bilinear interpolation. Fast, lower quality.
+    vng,        ///< Variable Number of Gradients. Good balance of speed/quality.
+    ppg,        ///< Patterned Pixel Grouping. Moderate quality.
+    ahd,        ///< Adaptive Homogeneity-Directed. Good quality, standard default.
+    dcb,        ///< Directional Color Filter Array interpolation with Bilateral filter.
+    ahd_mod,    ///< Modified AHD algorithm.
+    afd,        ///< Adaptive Frequency Domain demosaicing.
+    vcd,        ///< Variance of Color Difference.
+    mixed,      ///< Mixed demosaicing approach.
+    lmmse,      ///< Linear Minimum Mean Square Error.
+    amaze,      ///< Adaptive Malvar-He-Cutler algorithm. Best quality, slower.
+    dht,        ///< DHT-based demosaicing.
+    aahd,       ///< Advanced Adaptive Homogeneity-Directed.
+    none        ///< No demosaicing (return raw Bayer pattern).
+};
+
+/**
+ * @enum RawColorSpace
+ * @brief Color primaries and transfer function for RAW development output.
+ * The working color space determines the gamut of colors that can be represented
+ * and affects how edits are performed. Linear spaces are preferred for editing.
+ */
+enum class RawColorSpace : std::uint8_t {
+    raw,            ///< Raw sensor data, no color space conversion.
+    srgb,           ///< sRGB with gamma curve. Not recommended for editing.
+    srgb_linear,    ///< sRGB primaries with linear transfer. Good for editing.
+    adobe,          ///< Adobe RGB (1998). Wider gamut than sRGB.
+    wide,           ///< Wide gamut color space.
+    prophoto,       ///< ProPhoto RGB with gamma. Very wide gamut.
+    prophoto_linear,///< ProPhoto primaries with linear transfer. Best for editing (recommended).
+    xyz,            ///< CIE XYZ connection space.
+    aces,           ///< Academy Color Encoding System. Film industry standard.
+    dci_p3,         ///< DCI-P3 color space (LibRaw >= 0.21).
+    rec2020         ///< ITU-R BT.2020 color space (LibRaw >= 0.20).
+};
+
+/**
+ * @enum CameraMatrixMode
+ * @brief Controls when to use the embedded camera color profile matrix.
+ * Camera color matrices provide accurate color reproduction by converting
+ * from camera-specific color space to a standard working space.
+ */
+enum class CameraMatrixMode : std::uint8_t {
+    never = 0,      ///< Never use embedded color matrix.
+    dng_only = 1,   ///< Use only for DNG files (LibRaw default).
+    always = 3      ///< Always use embedded color matrix when available (recommended).
+};
+
+/**
+ * @enum FbddNoiseRd
+ * @brief FBDD (Fuzzy Block Denoising and Demosaicing) noise reduction level.
+ * Controls noise reduction applied BEFORE demosaicing. This can significantly
+ * improve demosaicing quality for noisy images, especially with AMaZE algorithm.
+ */
+enum class FbddNoiseRd : std::uint8_t {
+    off = 0,    ///< No FBDD noise reduction.
+    light = 1,  ///< Light FBDD reduction (recommended for most images).
+    full = 2    ///< Full FBDD reduction (for very noisy images).
+};
+
+/**
+ * @enum Orientation
+ * @brief Image orientation values matching EXIF orientation codes.
+ * Used to rotate/flip the image during RAW development based on camera
+ * orientation metadata or user preference.
+ */
+enum class Orientation : std::int8_t {
+    ignored = -1,       ///< Ignore orientation metadata.
+    normal = 0,         ///< Normal orientation (0°).
+    flip_horizontal = 1, ///< Mirror horizontal.
+    rotate_180 = 2,      ///< Rotate 180°.
+    flip_vertical = 3,   ///< Mirror vertical.
+    flip_h_rotate_90 = 4,  ///< Mirror horizontal and rotate 90° CW.
+    rotate_90_cw = 5,     ///< Rotate 90° clockwise.
+    flip_h_rotate_270 = 6, ///< Mirror horizontal and rotate 270° CW.
+    rotate_270_cw = 7,    ///< Rotate 270° clockwise (or 90° CCW).
+    flip_v_rotate_90 = 8   ///< Mirror vertical and rotate 90° CW.
+};
+
+/**
+ * @enum WhiteBalanceMode
+ * @brief White balance calculation mode for RAW development.
+ * Determines how the initial white balance multipliers are calculated.
+ * Camera WB is typically the most accurate starting point.
+ * @note This is a high-level abstraction. OIIO uses two separate flags
+ *       (use_camera_wb, use_auto_wb) with precedence rules.
+ */
+enum class WhiteBalanceMode : std::uint8_t {
+    none = 0,       ///< No white balance applied.
+    camera = 1,     ///< Use camera-recorded white balance (recommended default).
+    auto_wb = 2,    ///< Calculate white balance automatically from image data.
+    grey_box = 3,   ///< Calculate from a user-specified grey card region.
+    user_mul = 4    ///< Use user-specified custom white balance multipliers.
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RAW SETTINGS STRUCTURE
+// ═══════════════════════════════════════════════════════════════════════════════
+/**
+ * @struct RawSettings
+ * @brief Complete configuration for RAW image development via OIIO/LibRaw.
+ * This struct encapsulates all RAW processing parameters with sensible defaults
+ * optimized for quality. Parameters can be modified at runtime via setters.
+ * ## Architecture Notes
+ * - **Application-fixed settings**: color_space, demosaic, highlight_mode, balance_clamped
+ *   These are optimized for quality and not exposed to users directly.
+ * - **Potential user controls**: exposure, user_black, user_sat (via OperationDescriptor)
+ *   Users interact with these through the operations system.
+ * ## Default Configuration Rationale
+ * - **Demosaic**: amaze for best quality (slower but superior edge handling)
+ * - **ColorSpace**: prophoto_linear for widest editing gamut with linear response
+ * - **HighlightMode**: blend for natural highlight recovery without artifacts
+ * - **balance_clamped**: Enabled to prevent color shifts in clipped highlights
+ * - **use_camera_matrix**: always (3) for accurate color reproduction
+ * - **use_camera_wb**: Enabled for correct initial white balance
+ * - **fbdd_noiserd**: light for improved amaze quality with minimal detail loss
+ * @note Thread-safe for read access. Write operations should be synchronized externally.
+ */
+struct RawSettings {
+    // ═════════════════════════════════════════════════════════════════════════
+    // DEMOSAIC SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+private:
+    /** @brief Demosaicing algorithm to use for RAW development.
+     * The default is AMaZE, which provides the best quality with minimal artifacts,
+     * especially around edges and fine details. However, it is also the slowest
+     * algorithm. For faster performance at the cost of quality, users can switch
+     * to linear or VNG algorithms.
+    */
+    DemosaicAlgorithm m_demosaic{DemosaicAlgorithm::amaze};
+
+    /** @brief Flag indicating whether to output at half resolution.
+     * When true, the output will be at half the original resolution,
+     * which can improve loading performance but at the cost of detail.
+     */
+    bool m_half_size{false};
+
+public:
+    /**
+     * @brief Gets the demosaicing algorithm.
+     * @return The current demosaicing algorithm.
+     */
+    [[nodiscard]] constexpr DemosaicAlgorithm get_demosaic() const noexcept { return m_demosaic; }
+
+    /**
+     * @brief Sets the demosaicing algorithm.
+     * @param algorithm The demosaicing algorithm to use.
+     */
+    constexpr void set_demosaic(DemosaicAlgorithm algorithm) noexcept { m_demosaic = algorithm; }
+
+    /**
+     * @brief Gets the demosaic algorithm name as string (for OIIO attribute).
+     * @return The algorithm name string (e.g., "AMaZE").
+     * @note Converts enum name to OIIO format.
+     */
+    [[nodiscard]] std::string get_demosaic_string() const noexcept {
+        switch (m_demosaic) {
+            case DemosaicAlgorithm::linear:  return "linear";
+            case DemosaicAlgorithm::vng:     return "VNG";
+            case DemosaicAlgorithm::ppg:     return "PPG";
+            case DemosaicAlgorithm::ahd:     return "AHD";
+            case DemosaicAlgorithm::dcb:     return "DCB";
+            case DemosaicAlgorithm::ahd_mod: return "AHD-Mod";
+            case DemosaicAlgorithm::afd:     return "AFD";
+            case DemosaicAlgorithm::vcd:     return "VCD";
+            case DemosaicAlgorithm::mixed:   return "Mixed";
+            case DemosaicAlgorithm::lmmse:   return "LMMSE";
+            case DemosaicAlgorithm::amaze:   return "AMaZE";
+            case DemosaicAlgorithm::dht:     return "DHT";
+            case DemosaicAlgorithm::aahd:    return "AAHD";
+            case DemosaicAlgorithm::none:    return "none";
+            default:                         return "AHD";
+        }
+    }
+
+    /**
+     * @brief Checks if half-size output is enabled.
+     * @return true if output will be half resolution (faster loading).
+     */
+    [[nodiscard]] constexpr bool get_half_size() const noexcept { return m_half_size; }
+
+    /**
+     * @brief Enables or disables half-size output mode.
+     * @param half_size true for half resolution, false for full resolution.
+     */
+    constexpr void set_half_size(bool half_size) noexcept { m_half_size = half_size; }
+    // ═════════════════════════════════════════════════════════════════════════
+    // COLOR SPACE SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    /** @brief The color space to use for RAW output.
+     */
+    RawColorSpace m_color_space{RawColorSpace::prophoto_linear};
+
+public:
+    /**
+     * @brief Gets the output color space.
+     * @return The current color space.
+     */
+    [[nodiscard]] constexpr RawColorSpace get_color_space() const noexcept { return m_color_space; }
+
+    /**
+     * @brief Sets the output color space.
+     * @param color_space The color space to use for output.
+     */
+    constexpr void set_color_space(RawColorSpace color_space) noexcept { m_color_space = color_space; }
+
+    /**
+     * @brief Gets the color space name as string (for OIIO attribute).
+     * @return The color space name string (e.g., "ProPhoto-linear").
+     */
+    [[nodiscard]] std::string get_color_space_string() const noexcept {
+        switch (m_color_space) {
+            case RawColorSpace::raw:             return "raw";
+            case RawColorSpace::srgb:            return "sRGB";
+            case RawColorSpace::srgb_linear:     return "sRGB-linear";
+            case RawColorSpace::adobe:           return "Adobe";
+            case RawColorSpace::wide:            return "Wide";
+            case RawColorSpace::prophoto:        return "ProPhoto";
+            case RawColorSpace::prophoto_linear: return "ProPhoto-linear";
+            case RawColorSpace::xyz:             return "XYZ";
+            case RawColorSpace::aces:            return "ACES";
+            case RawColorSpace::dci_p3:          return "DCI-P3";
+            case RawColorSpace::rec2020:         return "Rec2020";
+            default:                             return "ProPhoto-linear";
+        }
+    }
+    // ═════════════════════════════════════════════════════════════════════════
+    // HIGHLIGHT RECOVERY SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    /** @brief The highlight recovery mode to use.
+     */
+    HighlightMode m_highlight_mode{HighlightMode::blend};
+
+    /** @brief Flag indicating whether to clamp the highlight balance.
+     * When true, this resolves color shifts in clipped highlights caused by
+     * unequal channel saturation. Note: This changes output datatype to HALF.
+     */
+    bool m_balance_clamped{true};
+
+public:
+    /**
+     * @brief Gets the highlight recovery mode.
+     * @return The current highlight mode.
+     */
+    [[nodiscard]] constexpr HighlightMode get_highlight_mode() const noexcept { return m_highlight_mode; }
+
+    /**
+     * @brief Sets the highlight recovery mode.
+     * @param mode The highlight mode to use.
+     */
+    constexpr void set_highlight_mode(HighlightMode mode) noexcept { m_highlight_mode = mode; }
+
+    /**
+     * @brief Gets the highlight mode value as integer (for OIIO attribute).
+     * @return The highlight mode integer value.
+     */
+    [[nodiscard]] constexpr int get_highlight_mode_value() const noexcept { 
+        return static_cast<int>(m_highlight_mode); 
+    }
+
+    /**
+     * @brief Checks if highlight clamping balance is enabled.
+     * @return true if balance_clamped is enabled.
+     * When enabled, this resolves color shifts in clipped highlights caused by
+     * unequal channel saturation. Note: This changes output datatype to HALF.
+     */
+    [[nodiscard]] constexpr bool get_balance_clamped() const noexcept { return m_balance_clamped; }
+
+    /**
+     * @brief Enables or disables highlight clamping balance.
+     * @param balance true to enable, false to disable.
+     */
+    constexpr void set_balance_clamped(bool balance) noexcept { m_balance_clamped = balance; }
+    // ═════════════════════════════════════════════════════════════════════════
+    // WHITE BALANCE SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    /**
+     * @brief Use camera white balance.
+     * OIIO precedence rules:
+     * 1. If use_camera_wb == 1 → use camera WB (ignores auto_wb, greybox, user_mul)
+     * 2. If use_camera_wb == 0 && use_auto_wb == 1 → auto WB from whole image
+     * 3. If use_camera_wb == 0 && use_auto_wb == 0 && greybox valid → greybox WB
+     * 4. If use_camera_wb == 0 && use_auto_wb == 0 && greybox empty → user_mul
+     */
+    bool m_use_camera_wb{true};
+    /** @brief Flag indicating whether to use auto white balance.
+     * When true, the white balance will be automatically calculated from the image.
+     */
+    bool m_use_auto_wb{false};
+    std::array<int, 4> m_grey_box{0, 0, 0, 0};           ///< X, Y, Width, Height for grey card WB
+    std::array<float, 4> m_user_mul{1.0f, 1.0f, 1.0f, 1.0f}; ///< R, G, B, G2 multipliers
+
+public:
+
+    /**
+     * @brief Checks if camera white balance is enabled.
+     * @return true if camera WB will be used.
+     */
+    [[nodiscard]] constexpr bool get_use_camera_wb() const noexcept { return m_use_camera_wb; }
+
+    /**
+     * @brief Enables or disables camera white balance.
+     * @param use_camera true to use camera WB, false to use alternative method.
+     */
+    constexpr void set_use_camera_wb(bool use_camera) noexcept { m_use_camera_wb = use_camera; }
+
+    /**
+     * @brief Checks if auto white balance is enabled.
+     * @return true if auto WB will be used (only if use_camera_wb is false).
+     */
+    [[nodiscard]] constexpr bool get_use_auto_wb() const noexcept { return m_use_auto_wb; }
+
+    /**
+     * @brief Enables or disables auto white balance.
+     * @param use_auto true to enable auto WB calculation.
+     * @note Only applies if use_camera_wb is false.
+     */
+    constexpr void set_use_auto_wb(bool use_auto) noexcept { m_use_auto_wb = use_auto; }
+
+    /**
+     * @brief Gets the white balance mode as high-level enum.
+     * @return The current white balance mode.
+     */
+    [[nodiscard]] constexpr WhiteBalanceMode get_white_balance_mode() const noexcept {
+        if (m_use_camera_wb) {
+            return WhiteBalanceMode::camera;
+        }
+        if (m_use_auto_wb) {
+            return WhiteBalanceMode::auto_wb;
+        }
+        // Check if grey_box is valid (non-zero size)
+        if (m_grey_box[2] > 0 && m_grey_box[3] > 0) {
+            return WhiteBalanceMode::grey_box;
+        }
+        return WhiteBalanceMode::user_mul;
+    }
+
+    /**
+     * @brief Sets the white balance mode from high-level enum.
+     * @param mode The white balance mode to use.
+     */
+    constexpr void set_white_balance_mode(WhiteBalanceMode mode) noexcept {
+        switch (mode) {
+            case WhiteBalanceMode::none:
+                m_use_camera_wb = false;
+                m_use_auto_wb = false;
+                break;
+            case WhiteBalanceMode::camera:
+                m_use_camera_wb = true;
+                m_use_auto_wb = false;
+                break;
+            case WhiteBalanceMode::auto_wb:
+                m_use_camera_wb = false;
+                m_use_auto_wb = true;
+                break;
+            case WhiteBalanceMode::grey_box:
+                m_use_camera_wb = false;
+                m_use_auto_wb = false;
+                break;
+            case WhiteBalanceMode::user_mul:
+                m_use_camera_wb = false;
+                m_use_auto_wb = false;
+                m_grey_box = {0, 0, 0, 0};  // Disable grey_box to use user_mul
+                break;
+        }
+    }
+    /**
+     * @brief Gets the grey box region for white balance calculation.
+     * @return Array containing {X, Y, Width, Height}. Zero size means disabled.
+     */
+    [[nodiscard]] constexpr const std::array<int, 4>& get_grey_box() const noexcept { return m_grey_box; }
+
+    /**
+     * @brief Sets the grey box region for white balance calculation.
+     * @param x X coordinate of top-left corner.
+     * @param y Y coordinate of top-left corner.
+     * @param width Width of the region.
+     * @param height Height of the region.
+     * @note Automatically disables use_camera_wb and use_auto_wb.
+     */
+    constexpr void set_grey_box(int x, int y, int width, int height) noexcept {
+        m_grey_box = {x, y, width, height};
+        // Disable other WB modes to use grey_box
+        m_use_camera_wb = false;
+        m_use_auto_wb = false;
+    }
+
+    /**
+     * @brief Gets the user-defined white balance multipliers.
+     * @return Array containing {R, G, B, G2} multipliers.
+     */
+    [[nodiscard]] constexpr const std::array<float, 4>& get_user_mul() const noexcept { return m_user_mul; }
+
+    /**
+     * @brief Sets the user-defined white balance multipliers.
+     * @param r Red channel multiplier.
+     * @param g Green channel multiplier.
+     * @param b Blue channel multiplier.
+     * @param g2 Second green channel multiplier (for Bayer RGGB patterns).
+     * @note Automatically disables use_camera_wb, use_auto_wb, and clears grey_box.
+     */
+    constexpr void set_user_mul(float r, float g, float b, float g2) noexcept {
+        m_user_mul = {r, g, b, g2};
+        // Disable other WB modes to use user_mul
+        m_use_camera_wb = false;
+        m_use_auto_wb = false;
+        m_grey_box = {0, 0, 0, 0};
+    }
+    // ═════════════════════════════════════════════════════════════════════════
+    // COLOR MATRIX SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    /** @brief The camera color matrix usage mode. */
+    CameraMatrixMode m_camera_matrix{CameraMatrixMode::always};
+
+public:
+    /**
+     * @brief Gets the camera color matrix usage mode.
+     * @return The current camera matrix mode.
+     */
+    [[nodiscard]] constexpr CameraMatrixMode get_camera_matrix() const noexcept { return m_camera_matrix; }
+
+    /**
+     * @brief Sets the camera color matrix usage mode.
+     * @param mode The camera matrix mode to use.
+     */
+     constexpr void set_camera_matrix(CameraMatrixMode mode) noexcept { m_camera_matrix = mode; }
+
+     /**
+     * @brief Gets the camera matrix mode value as integer (for OIIO attribute).
+     * @return The camera matrix mode integer value.
+     */
+    [[nodiscard]] constexpr int get_camera_matrix_value() const noexcept { 
+        return static_cast<int>(m_camera_matrix); 
+    }
+    // ═════════════════════════════════════════════════════════════════════════
+    // EXPOSURE SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+private:
+    float m_exposure{1.0f};             ///< Exposure multiplier (0.25 to 8.0)
+    bool m_auto_bright{false};           ///< Auto brightness adjustment
+    bool m_apply_scene_linear_scale{false};///< Apply scene-linear scaling
+    float m_camera_to_scene_linear_scale{2.2222222222222223f}; ///< Scale factor for scene-linear
+
+public:
+    /**
+     * @brief Gets the exposure multiplier.
+     * @return The exposure multiplier (1.0 = no correction).
+     * Range: 0.25 (2 stops darken) to 8.0 (3 stops brighten).
+     */
+    [[nodiscard]] constexpr float get_exposure() const noexcept { return m_exposure; }
+
+    /**
+     * @brief Sets the exposure multiplier.
+     * @param exposure The exposure multiplier (0.25 to 8.0).
+     */
+    constexpr void set_exposure(float exposure) noexcept { m_exposure = exposure; }
+
+    /**
+     * @brief Checks if auto brightness is enabled.
+     * @return true if auto brightness adjustment is enabled.
+     */
+    [[nodiscard]] constexpr bool get_auto_bright() const noexcept { return m_auto_bright; }
+
+    /**
+     * @brief Enables or disables auto brightness.
+     * @param auto_bright true to enable auto brightness.
+     */
+    constexpr void set_auto_bright(bool auto_bright) noexcept { m_auto_bright = auto_bright; }
+
+    /**
+     * @brief Checks if scene-linear scaling is applied.
+     * @return true if scene-linear scaling is enabled.
+     * When enabled, applies scaling so 18% grey card has value 0.18.
+     */
+    [[nodiscard]] constexpr bool get_apply_scene_linear_scale() const noexcept { return m_apply_scene_linear_scale; }
+
+    /**
+     * @brief Enables or disables scene-linear scaling.
+     * @param apply true to enable scene-linear scaling.
+     */
+    constexpr void set_apply_scene_linear_scale(bool apply) noexcept { m_apply_scene_linear_scale = apply; }
+
+    /**
+     * @brief Gets the camera-to-scene linear scale factor.
+     * @return The scale factor (default: 1.0/0.45 ≈ 2.222).
+     */
+    [[nodiscard]] constexpr float get_camera_to_scene_linear_scale() const noexcept { 
+        return m_camera_to_scene_linear_scale; 
+    }
+
+    /**
+     * @brief Sets the camera-to-scene linear scale factor.
+     * @param scale The scale factor to use.
+     */
+    constexpr void set_camera_to_scene_linear_scale(float scale) noexcept { 
+        m_camera_to_scene_linear_scale = scale; 
+    }
+    // ═════════════════════════════════════════════════════════════════════════
+    // BLACK/WHITE POINT SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    int m_user_black{-1};    ///< User-specified black point (<0 = auto)
+    int m_user_sat{0};       ///< User-specified saturation point (0 = auto)
+    float m_adjust_maximum_thr{0.0f}; ///< Auto-adjust maximum threshold
+
+public:
+    /**
+     * @brief Gets the user-specified black point.
+     * @return The black point value (<0 means auto).
+     */
+    [[nodiscard]] constexpr int get_user_black() const noexcept { return m_user_black; }
+
+    /**
+     * @brief Sets the user-specified black point.
+     * @param black The black point value. Use negative for auto.
+     */
+    constexpr void set_user_black(int black) noexcept { m_user_black = black; }
+
+    /**
+     * @brief Gets the user-specified saturation point.
+     * @return The saturation point value (0 means auto).
+     */
+    [[nodiscard]] constexpr int get_user_sat() const noexcept { return m_user_sat; }
+
+    /**
+     * @brief Sets the user-specified saturation point.
+     * @param sat The saturation point value. Use 0 for auto.
+     */
+    constexpr void set_user_sat(int sat) noexcept { m_user_sat = sat; }
+
+    /**
+     * @brief Gets the auto-adjust maximum threshold.
+     * @return The threshold value (0 = disabled).
+     */
+    [[nodiscard]] constexpr float get_adjust_maximum_thr() const noexcept { return m_adjust_maximum_thr; }
+
+    /**
+     * @brief Sets the auto-adjust maximum threshold.
+     * @param thr The threshold value. Use 0 to disable.
+     */
+    constexpr void set_adjust_maximum_thr(float thr) noexcept { m_adjust_maximum_thr = thr; }
+    // ═════════════════════════════════════════════════════════════════════════
+    // NOISE REDUCTION SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    /** @brief The FBDD noise reduction level. */
+    FbddNoiseRd m_fbdd_noiserd{FbddNoiseRd::light};
+    /** @brief The wavelet denoising threshold. */
+    float m_threshold{0.0f};    ///< Wavelet denoising threshold (0-1000+)
+
+public:
+    /**
+     * @brief Gets the FBDD noise reduction level.
+     * @return The current FBDD noise reduction setting.
+     */
+    [[nodiscard]] constexpr FbddNoiseRd get_fbdd_noiserd() const noexcept { return m_fbdd_noiserd; }
+
+    /**
+     * @brief Sets the FBDD noise reduction level.
+     * @param noiserd The FBDD noise reduction level.
+     */
+    constexpr void set_fbdd_noiserd(FbddNoiseRd noiserd) noexcept { m_fbdd_noiserd = noiserd; }
+
+    /**
+     * @brief Gets the FBDD noise reduction value as integer (for OIIO attribute).
+     * @return The FBDD noise reduction integer value.
+     */
+    [[nodiscard]] constexpr int get_fbdd_noiserd_value() const noexcept { 
+        return static_cast<int>(m_fbdd_noiserd); 
+    }
+
+    /**
+     * @brief Gets the wavelet denoising threshold.
+     * @return The threshold value (0 = disabled).
+     * Sensible values are between 100 and 1000.
+     */
+    [[nodiscard]] constexpr float get_threshold() const noexcept { return m_threshold; }
+
+    /**
+     * @brief Sets the wavelet denoising threshold.
+     * @param threshold The threshold value. Use 0 to disable.
+     */
+    constexpr void set_threshold(float threshold) noexcept { m_threshold = threshold; }
+    // ═════════════════════════════════════════════════════════════════════════
+    // CHROMATIC ABERRATION CORRECTION
+    // ═════════════════════════════════════════════════════════════════════════
+private:
+    std::array<float, 2> m_aber{1.0f, 1.0f}; ///< Red and blue scale factors
+
+public:
+
+    /**
+     * @brief Gets the chromatic aberration correction factors.
+     * @return Array containing {red_scale, blue_scale}.
+     * Default (1.0, 1.0) means no correction.
+     * Sensible values are very close to 1.0.
+     */
+    [[nodiscard]] constexpr const std::array<float, 2>& get_aber() const noexcept { return m_aber; }
+
+    /**
+     * @brief Sets the chromatic aberration correction factors.
+     * @param red Red channel scale factor.
+     * @param blue Blue channel scale factor.
+     */
+    constexpr void set_aber(float red, float blue) noexcept { m_aber = {red, blue}; }
+    // ═════════════════════════════════════════════════════════════════════════
+    // ORIENTATION SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    /** @brief The user-specified orientation. */
+    Orientation m_user_flip{Orientation::ignored};
+
+public:
+    /**
+     * @brief Gets the user-specified orientation.
+     * @return The orientation value.
+     */
+    [[nodiscard]] constexpr Orientation get_user_flip() const noexcept { return m_user_flip; }
+
+    /**
+     * @brief Sets the user-specified orientation.
+     * @param flip The orientation to use.
+     */
+    constexpr void set_user_flip(Orientation flip) noexcept { m_user_flip = flip; }
+
+    /**
+     * @brief Gets the orientation value as integer (for OIIO attribute).
+     * @return The orientation integer value.
+     */
+    [[nodiscard]] constexpr int get_user_flip_value() const noexcept { 
+        return static_cast<int>(m_user_flip); 
+    }
+    // ═════════════════════════════════════════════════════════════════════════
+    // CROP SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    std::array<int, 4> m_crop_box{0, 0, 0, 0}; ///< X, Y, Width, Height
+
+public:
+    /**
+     * @brief Gets the crop box region.
+     * @return Array containing {X, Y, Width, Height}. Zero size means auto-crop.
+     */
+    [[nodiscard]] constexpr const std::array<int, 4>& get_crop_box() const noexcept { return m_crop_box; }
+
+    /**
+     * @brief Sets the crop box region.
+     * @param x X coordinate of top-left corner.
+     * @param y Y coordinate of top-left corner.
+     * @param width Width of the crop region.
+     * @param height Height of the crop region.
+     */
+    constexpr void set_crop_box(int x, int y, int width, int height) noexcept {
+        m_crop_box = {x, y, width, height};
+    }
+    // ═════════════════════════════════════════════════════════════════════════
+    // MEMORY AND LOADING SETTINGS
+    // ═════════════════════════════════════════════════════════════════════════
+
+private:
+    int m_max_raw_memory_mb{4096}; ///< Maximum memory for RAW processing (MB)
+    bool m_force_load{true};     ///< Force decompress during initialization
+
+public:
+
+    /**
+     * @brief Gets the maximum memory allocation for RAW processing.
+     * @return The maximum memory in megabytes.
+     */
+    [[nodiscard]] constexpr int get_max_raw_memory_mb() const noexcept { return m_max_raw_memory_mb; }
+
+    /**
+     * @brief Sets the maximum memory allocation for RAW processing.
+     * @param max_mb The maximum memory in megabytes.
+     */
+    constexpr void set_max_raw_memory_mb(int max_mb) noexcept { m_max_raw_memory_mb = max_mb; }
+
+    /**
+     * @brief Checks if force load is enabled.
+     * @return true if decompression is forced during initialization.
+     */
+    [[nodiscard]] constexpr bool get_force_load() const noexcept { return m_force_load; }
+
+    /**
+     * @brief Enables or disables force load.
+     * @param force true to force decompression during initialization.
+     */
+    constexpr void set_force_load(bool force) noexcept { m_force_load = force; }
+    // ═════════════════════════════════════════════════════════════════════════
+    // PRESET FACTORY METHODS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Creates a RawSettings configured for maximum processing speed.
+     * @return RawSettings with speed-optimized configuration.
+     * ## Configuration Rationale
+     * | Parameter | Value | Reason |
+     * |-----------|-------|--------|
+     * | demosaic | linear | Fastest algorithm |
+     * | color_space | srgb_linear | Minimal color conversion |
+     * | highlight_mode | clip | No reconstruction overhead |
+     * | half_size | true | Half resolution = 1/4 pixels |
+     * | fbdd_noiserd | off | No pre-demosaic denoising |
+     * | force_load | false | Lazy loading |
+     * | balance_clamped | false | No additional processing |
+     * @note Use for preview/thumbnail generation or when speed is critical.
+     * @warning Quality will be significantly reduced compared to other presets.
+     */
+    [[nodiscard]] static constexpr RawSettings fast_settings() noexcept {
+        RawSettings settings;
+        settings.m_demosaic = DemosaicAlgorithm::linear;
+        settings.m_color_space = RawColorSpace::srgb_linear;
+        settings.m_highlight_mode = HighlightMode::clip;
+        settings.m_balance_clamped = false;
+        settings.m_half_size = true;
+        settings.m_fbdd_noiserd = FbddNoiseRd::off;
+        settings.m_force_load = false;
+        settings.m_camera_matrix = CameraMatrixMode::dng_only;
+        settings.m_use_camera_wb = true;
+        settings.m_use_auto_wb = false;
+        return settings;
+    }
+
+    /**
+     * @brief Creates a RawSettings configured for maximum image quality.
+     * @return RawSettings with quality-optimized configuration.
+     * ## Configuration Rationale
+     * | Parameter | Value | Reason |
+     * |-----------|-------|--------|
+     * | demosaic | amaze | Best edge handling, minimal artifacts |
+     * | color_space | prophoto_linear | Widest gamut for editing |
+     * | highlight_mode | rebuild | Best recovery for clipped highlights |
+     * | half_size | false | Full resolution |
+     * | fbdd_noiserd | light | Improves amaze accuracy |
+     * | force_load | true | All metadata available |
+     * | balance_clamped | true | Prevents highlight color shifts |
+     * | use_camera_matrix | always | Accurate color reproduction |
+     * @note Use for final export or when quality is paramount.
+     * @warning Processing will be significantly slower than other presets.
+     */
+    [[nodiscard]] static constexpr RawSettings quality_settings() noexcept {
+        RawSettings settings;
+        settings.m_demosaic = DemosaicAlgorithm::amaze;
+        settings.m_color_space = RawColorSpace::prophoto_linear;
+        settings.m_highlight_mode = HighlightMode::rebuild;
+        settings.m_balance_clamped = true;
+        settings.m_half_size = false;
+        settings.m_fbdd_noiserd = FbddNoiseRd::light;
+        settings.m_force_load = true;
+        settings.m_camera_matrix = CameraMatrixMode::always;
+        settings.m_use_camera_wb = true;
+        settings.m_use_auto_wb = false;
+        return settings;
+    }
+
+    /**
+     * @brief Creates a RawSettings configured for balanced performance and quality.
+     * @return RawSettings with balanced configuration.
+     * ## Configuration Rationale
+     * | Parameter | Value | Reason |
+     * |-----------|-------|--------|
+     * | demosaic | ahd | Good quality/speed balance |
+     * | color_space | prophoto_linear | Wide gamut for editing |
+     * | highlight_mode | blend | Natural highlight recovery |
+     * | half_size | false | Full resolution |
+     * | fbdd_noiserd | light | Moderate noise reduction |
+     * | force_load | true | Metadata available |
+     * | balance_clamped | true | Prevents highlight color shifts |
+     * | use_camera_matrix | always | Accurate color reproduction |
+     * @note This is the recommended default for interactive editing sessions.
+     * @note Provides ~2-3x faster processing than quality_settings() with good quality.
+     */
+    [[nodiscard]] static constexpr RawSettings performance_settings() noexcept {
+        RawSettings settings;
+        settings.m_demosaic = DemosaicAlgorithm::ahd;
+        settings.m_color_space = RawColorSpace::prophoto_linear;
+        settings.m_highlight_mode = HighlightMode::blend;
+        settings.m_balance_clamped = true;
+        settings.m_half_size = false;
+        settings.m_fbdd_noiserd = FbddNoiseRd::light;
+        settings.m_force_load = true;
+        settings.m_camera_matrix = CameraMatrixMode::always;
+        settings.m_use_camera_wb = true;
+        settings.m_use_auto_wb = false;
+        return settings;
+    }
+    // ═════════════════════════════════════════════════════════════════════════
+    // UTILITY METHODS
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Resets all settings to their default values.
+     * Default values are optimized for quality (same as quality_settings()).
+     */
+    void reset_to_defaults() noexcept {
+        *this = RawSettings{};
+    }
+
+    /**
+     * @brief Checks if the current configuration matches quality preset.
+     * @return true if configuration uses quality-optimized settings.
+     */
+    [[nodiscard]] constexpr bool is_quality_configuration() const noexcept {
+        return m_demosaic == DemosaicAlgorithm::amaze &&
+               m_color_space == RawColorSpace::prophoto_linear &&
+               m_highlight_mode >= HighlightMode::blend &&
+               m_balance_clamped &&
+               m_camera_matrix == CameraMatrixMode::always;
+    }
+
+    /**
+     * @brief Checks if the current configuration matches fast preset.
+     * @return true if configuration uses speed-optimized settings.
+     */
+    [[nodiscard]] constexpr bool is_fast_configuration() const noexcept {
+        return m_half_size &&
+               m_demosaic == DemosaicAlgorithm::linear;
+    }
+
+    /**
+     * @brief Checks if the current configuration matches performance preset.
+     * @return true if configuration uses balanced performance settings.
+     */
+    [[nodiscard]] constexpr bool is_performance_configuration() const noexcept {
+        return m_demosaic == DemosaicAlgorithm::ahd &&
+               m_color_space == RawColorSpace::prophoto_linear &&
+               m_highlight_mode == HighlightMode::blend &&
+               m_balance_clamped &&
+               !m_half_size;
+    }
+};
+} // namespace Raw
+} // namespace CaptureMoment::Core::ImageConfig

--- a/core/include/managers/source_manager.h
+++ b/core/include/managers/source_manager.h
@@ -104,6 +104,16 @@ private:
      */
     [[nodiscard]] bool isLoaded_unsafe() const;
 
+
+    /**
+     * @brief Loads an image file via OIIO ImageCache into an ImageBuf (F32).
+     * @param path The file path to load.
+     * @param config Optional OIIO configuration attributes (for RAW, HEIF, etc.).
+     * @return The loaded ImageBuf on success, or a CoreError on failure.
+     */
+    [[nodiscard]] std::expected<OIIO::ImageBuf, ErrorHandling::CoreError>
+    loadImageBuffer(std::string_view path, const OIIO::ImageSpec* config = nullptr);
+
     // ============================================================
     // RAW File Handling
     // ============================================================
@@ -121,6 +131,18 @@ private:
     [[nodiscard]] bool isRawFile(std::string_view path) const;
 
     /**
+     * @brief Checks if a file path refers to a HEIC image format.
+     *
+     * Determines whether the file extension corresponds to a HEIC format
+     * that may require special processing (e.g., reorientation).
+     *
+     * @param path The file path to check.
+     * @return true If the file is a HEIC format.
+     * @return false If the file is not a HEIC format.
+     */
+    [[nodiscard]] bool isHeicFile(std::string_view path) const;
+
+    /**
      * @brief Loads a RAW image file with optimized LibRaw settings.
      *
      * This method handles RAW camera files (NEF, CR2, ARW, DNG, etc.) by configuring
@@ -134,7 +156,20 @@ private:
      * @param path The path to the RAW file.
      * @return std::expected<void, CoreError> Success or error code.
      */
-    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> loadRawFile(const std::string& path);
+    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> loadRawFile(std::string_view path);
+
+    /**
+     * @brief Loads a HEIC image file with optimized libheif settings.
+     *
+     * This method handles HEIC files, which often require special handling for
+     * orientation and alpha. It configures libheif to:
+     * - Automatically reorient based on EXIF metadata (recommended for smartphone photos).
+     * - Preserve unassociated alpha if present.
+     *
+     * @param path The path to the HEIC file.
+     * @return std::expected<void, CoreError> Success or error code.
+     */
+    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> loadHeicFile(std::string_view path);
 
     /**
      * @brief Loads a standard image file (JPEG, PNG, TIFF, etc.).
@@ -145,7 +180,7 @@ private:
      * @param path The path to the image file.
      * @return std::expected<void, CoreError> Success or error code.
      */
-    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> loadStandardFile(const std::string& path);
+    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> loadStandardFile(std::string_view path);
 
     /**
      * @brief Converts an OIIO ImageBuf to RGBA_F32 internal format.

--- a/core/include/managers/source_manager.h
+++ b/core/include/managers/source_manager.h
@@ -103,6 +103,57 @@ private:
      * Assumes caller holds m_mutex.
      */
     [[nodiscard]] bool isLoaded_unsafe() const;
+
+    // ============================================================
+    // RAW File Handling
+    // ============================================================
+
+    /**
+     * @brief Checks if a file path refers to a RAW image format.
+     *
+     * Determines whether the file extension corresponds to a RAW camera format
+     * (e.g., .NEF, .CR2, .ARW, .DNG) that requires special processing.
+     *
+     * @param path The file path to check.
+     * @return true If the file is a RAW format.
+     * @return false If the file is a standard image format (JPEG, PNG, TIFF).
+     */
+    [[nodiscard]] bool isRawFile(std::string_view path) const;
+
+    /**
+     * @brief Loads a RAW image file with optimized LibRaw settings.
+     *
+     * This method handles RAW camera files (NEF, CR2, ARW, DNG, etc.) by configuring
+     * OIIO/LibRaw with appropriate settings for photo editing:
+     * - Full resolution output
+     * - AHD demosaicing algorithm
+     * - Linear color space (sRGB-linear)
+     * - Camera white balance preserved
+     * - Highlight recovery enabled
+     *
+     * @param path The path to the RAW file.
+     * @return std::expected<void, CoreError> Success or error code.
+     */
+    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> loadRawFile(const std::string& path);
+
+    /**
+     * @brief Loads a standard image file (JPEG, PNG, TIFF, etc.).
+     *
+     * This method handles non-RAW image formats using OIIO ImageCache.
+     * No special RAW processing is applied.
+     *
+     * @param path The path to the image file.
+     * @return std::expected<void, CoreError> Success or error code.
+     */
+    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> loadStandardFile(const std::string& path);
+
+    /**
+     * @brief Converts an OIIO ImageBuf to RGBA_F32 internal format.
+     *
+     * @param src_buf Source buffer (any format).
+     * @return std::expected<void, CoreError> Success or error code.
+     */
+    [[nodiscard]] std::expected<void, ErrorHandling::CoreError> convertToRgbaInternal(OIIO::ImageBuf&& src_buf);
 };
 
 } // namespace Managers

--- a/core/include/pch.h
+++ b/core/include/pch.h
@@ -30,6 +30,7 @@
 // ============================================================
 #include "Halide.h"     // Halide library headers
 #include <spdlog/spdlog.h> // spdlog library headers
+#include <magic_enum/magic_enum.hpp> // magic_enum for enum-string conversions
 
 // ============================================================
 // 3. Internal Core Modules (Umbrella Headers Only)
@@ -45,7 +46,8 @@
 #include "common/error_handling/core_error.h" // Error handling types
 
 // 3b. Core Modules (Order might be less critical with umbrella headers)
-#include "common/common.h"            // Umbrella for common types/utils (if exists)
+#include "common/common.h"            // Umbrella for common types
+#include "utils/utils.h"              // Umbrella for utility functions
 #include "operations/operations.h"    // Operations and factories
 #include "image_processing/image_processing.h" // Hardware abstraction, factories, etc.
 #include "pipeline/pipeline.h"        // Pipeline executors, builders, etc.
@@ -55,12 +57,5 @@
 #include "engine/engine.h"           // Orchestrators like PhotoEngine
 #include "serializer/serializer.h"   // Serialization interfaces, providers, etc.
 #include "workers/workers.h"         // Worker interfaces, builders, registries, etc.
+#include "image_config/image_config.h"   // Image operation configuration structures
 
-
-// ============================================================
-// 4. Utility Headers (Could be included by internal modules)
-//    Placed here if not part of an umbrella header.
-//    Ensure utilities don't depend on other core modules.
-// ============================================================
-#include "utils/to_string_utils.h"   // Generic string conversion utilities
-#include "utils/image_conversion.h"  // Image format conversion utilities

--- a/core/include/utils/color_space_utils.h
+++ b/core/include/utils/color_space_utils.h
@@ -1,0 +1,83 @@
+/**
+ * @file color_space_utils.h
+ * @brief Utilities for analyzing and converting image color spaces.
+ * @author CaptureMoment Team
+ * @date 2026
+ *
+ * Provides functions to:
+ * - Detect if an image's pixel data is linear via OIIO metadata.
+ * - Convert an image to a target color space via OIIO colorconvert.
+ *
+ * OIIO automatically detects and stores the color space in the
+ * "oiio:ColorSpace" ImageSpec attribute when reading a file.
+ * These utilities read that metadata — no manual file inspection needed.
+ */
+
+#pragma once
+
+#include <OpenImageIO/imagebuf.h>
+#include "common/error_handling/core_error.h"
+
+#include <expected>
+#include <string>
+#include <utility>
+
+namespace CaptureMoment::Core::Utils {
+
+/**
+ * @brief Result of a color space analysis.
+ *
+ * First element: `true` if the image data uses a linear transfer function.
+ * Second element: the detected color space name (CIF token).
+ *               Empty if OIIO could not determine it.
+ */
+using ColorSpaceInfo = std::pair<bool, std::string>;
+
+/**
+ * @brief Checks whether an OIIO-detected color space token represents linear data.
+ *
+ * Matches against known CIF (Color Interop Forum) linear tokens:
+ * - "lin_rec709_scene" (synonyms: "lin_rec709", "lin_srgb", "Linear")
+ * - "lin_ap1_scene"     (synonym: "ACEScg")
+ * - "lin_ap0_scene"
+ * - "scene_linear"      (OCIO role)
+ *
+ * @param colorspace The color space name from OIIO metadata.
+ * @return true if the token represents a linear transfer function.
+ */
+[[nodiscard]] bool isLinearToken(std::string_view colorspace) noexcept;
+
+/**
+ * @brief Analyzes whether an image's pixel data is stored in a linear color space.
+ *
+ * Reads the "oiio:ColorSpace" attribute that OIIO sets automatically
+ * during file reading. Does not read the file — uses OIIO's metadata only.
+ *
+ * @param spec The OIIO ImageSpec to inspect.
+ * @return ColorSpaceInfo with linear status and detected color space name.
+ *
+ * @note If OIIO did not set "oiio:ColorSpace" (e.g., BMP, ICO without metadata),
+ *       returns {false, ""}. The caller should apply a fallback strategy.
+ */
+[[nodiscard]] ColorSpaceInfo analyzeColorSpace(const OIIO::ImageSpec& spec) noexcept;
+
+/**
+ * @brief Converts an image buffer to a target color space (in-place).
+ *
+ * Reads the source color space from the buffer's OIIO metadata
+ * ("oiio:ColorSpace") and converts to the specified target.
+ *
+ * @param image The image buffer to convert (modified in-place).
+ * @param target_cs The target color space CIF token (e.g., "lin_rec709_scene").
+ * @return Success or CoreError on failure.
+ */
+[[nodiscard]] std::expected<void, ErrorHandling::CoreError>
+transformToColorSpace(OIIO::ImageBuf& image, std::string_view target_cs);
+
+/**
+ * @brief Extracts the color space name from an OIIO image buffer metadata.
+ * @return The detected color space name, or empty string if not found.
+ */
+[[nodiscard]] std::string getColorSpace(const OIIO::ImageBuf& buf) noexcept;
+
+} // namespace CaptureMoment::Core::Utils

--- a/core/include/utils/utils.h
+++ b/core/include/utils/utils.h
@@ -1,0 +1,31 @@
+/**
+ * @file utils.h
+ * @brief Umbrella header for the Utils module of the CaptureMoment Core Library.
+ *
+ * This header provides a single entry point for the `CaptureMoment::Core::Utils` namespace.
+ * Including this file grants access to all fundamental data structures, types,
+ * and utilities defined within the Utils module.
+ *
+ * @author CaptureMoment Team
+ * @date 2026
+ */
+
+#pragma once
+
+/** 
+ * @brief Color Space Utilities
+ */
+
+#include "utils/color_space_utils.h"
+
+/**
+ * @brief Image Conversion Utilities
+ */
+#include "utils/image_conversion.h"
+
+/**
+ * @brief Definition of supported pixel formats (e.g., RGBA_U8, RGBA_F32).
+ */
+#include "utils/to_string_utils.h"
+
+// Add other common headers as needed

--- a/core/src/managers/source_manager.cpp
+++ b/core/src/managers/source_manager.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "managers/source_manager.h"
+#include "image_config/raw_settings.h"
+#include "image_config/heic_settings.h"
+#include "utils/color_space_utils.h"
 
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imageio.h>
@@ -16,29 +19,52 @@
 namespace CaptureMoment::Core::Managers {
 
 // Global static members for cache management
-static std::shared_ptr<OIIO::ImageCache> s_globalCachePtr = nullptr;
-static std::once_flag s_cacheInitFlag;
+static std::shared_ptr<OIIO::ImageCache> s_global_cache_ptr { nullptr };
+static std::once_flag s_cache_init_flag;
+
+/**
+ * @brief Checks if a file path has one of the specified extensions.
+ * @param path The file path to check.
+ * @param extensions The list of extensions to compare against.
+ * @return true If the file has one of the specified extensions.
+ * @return false If the file does not have any of the specified extensions.
+ */
+[[nodiscard]] static bool hasExtension(std::string_view path, std::span<const std::string_view> extensions) noexcept
+{
+    std::string lower_path(path);
+    std::transform(lower_path.begin(), lower_path.end(), lower_path.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    for (const auto& ext : extensions)
+    {
+        if (lower_path.size() >= ext.size() &&
+            lower_path.compare(lower_path.size() - ext.size(), ext.size(), ext) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
 
 OIIO::ImageCache* SourceManager::getGlobalCache()
 {
-    std::call_once(s_cacheInitFlag, []() {
-        s_globalCachePtr = OIIO::ImageCache::create();
-        
-        if (s_globalCachePtr) {
-            s_globalCachePtr->attribute("max_memory_MB", 2048.0f);
-            spdlog::debug("[SourceManager] OIIO ImageCache created: 2GB limit");
+    std::call_once(s_cache_init_flag, []() {
+        s_global_cache_ptr = OIIO::ImageCache::create();
+
+        if (s_global_cache_ptr) {
+            s_global_cache_ptr->attribute("max_memory_MB", 2048.0f);
+            spdlog::debug("[SourceManager::getGlobalCache]: OIIO ImageCache created: 2GB limit");
         } else {
-            spdlog::critical("[SourceManager] Failed to create OIIO ImageCache");
+            spdlog::critical("[SourceManager::getGlobalCache]: Failed to create OIIO ImageCache");
         }
     });
-    return s_globalCachePtr.get();
+    return s_global_cache_ptr.get();
 }
 
 SourceManager::SourceManager()
     : m_cache(getGlobalCache())
 {
     if (!m_cache) {
-        spdlog::critical("[SourceManager] Failed to get global ImageCache");
+        spdlog::critical("[SourceManager::SourceManager]: Failed to get global ImageCache");
         throw std::runtime_error("SourceManager: Initialization failed");
     }
 }
@@ -51,7 +77,7 @@ SourceManager::~SourceManager()
 std::expected<void, ErrorHandling::CoreError> SourceManager::loadFile(std::string_view path)
 {
     if (path.empty()) {
-        spdlog::warn("[SourceManager::loadFile] Empty file path");
+        spdlog::warn("[SourceManager::loadFile]: Empty file path");
         return std::unexpected(ErrorHandling::CoreError::FileNotFound);
     }
 
@@ -61,77 +87,259 @@ std::expected<void, ErrorHandling::CoreError> SourceManager::loadFile(std::strin
         unloadInternal();
     }
 
-    spdlog::info("[SourceManager::loadFile] Loading: '{}'", path);
+    spdlog::info("[SourceManager::loadFile]: Loading: '{}'", path);
 
-    try {
-        // ============================================================
-        // Step 1: Load via OIIO ImageCache
-        // ============================================================
-        OIIO::ImageBuf src_buf(std::string(path), 0, 0, s_globalCachePtr);
-        
-        if (!src_buf.read(0, 0, true, OIIO::TypeDesc::FLOAT)) {
-            spdlog::error("[SourceManager::loadFile] Failed to read '{}': {}", 
-                          path, src_buf.geterror());
+    // Dispatch based on file type
+    if (isRawFile(path)) {
+        return loadRawFile(path);
+    } else if (isHeicFile(path)) {
+        return loadHeicFile(path);
+    }
+
+    return loadStandardFile(path);
+}
+
+bool SourceManager::isRawFile(std::string_view path) const
+{
+    static const std::array<std::string_view, 25> raw_extensions = {
+        ".nef", ".cr2", ".cr3", ".arw", ".dng", ".raw", ".rw2",
+        ".orf", ".sr2", ".raf", ".mrw", ".pef", ".srw", ".x3f",
+        ".3fr", ".iiq", ".kdc", ".mef", ".nrw", ".srw", ".crw",
+        ".mos", ".erf", ".dc2", ".dcr"
+    };
+
+    return hasExtension(path, raw_extensions);
+}
+
+bool SourceManager::isHeicFile(std::string_view path) const
+{
+    static const std::array<std::string_view, 3> heic_extensions = {
+        ".heic", ".heif", ".avif"
+    };
+
+    return hasExtension(path, heic_extensions);
+}
+
+std::expected<void, ErrorHandling::CoreError> SourceManager::loadRawFile(std::string_view path)
+{
+    spdlog::debug("[SourceManager::loadRawFile]: Processing RAW file: {}", path);
+
+    // ============================================================
+    // Configure OIIO/LibRaw with optimized settings
+    // ============================================================
+    ImageConfig::Raw::RawSettings settings;
+    settings.set_demosaic(ImageConfig::Raw::DemosaicAlgorithm::amaze);
+    settings.set_color_space(ImageConfig::Raw::RawColorSpace::prophoto_linear);
+    settings.set_highlight_mode(ImageConfig::Raw::HighlightMode::blend);
+    settings.set_balance_clamped(true);
+    settings.set_use_camera_wb(true);
+    settings.set_fbdd_noiserd(ImageConfig::Raw::FbddNoiseRd::light);
+    settings.set_camera_matrix(ImageConfig::Raw::CameraMatrixMode::always);
+
+    OIIO::ImageSpec config;
+    config.attribute("raw:Demosaic", settings.get_demosaic_string());
+    config.attribute("raw:ColorSpace", settings.get_color_space_string());
+    config.attribute("raw:HighlightMode", settings.get_highlight_mode_value());
+    config.attribute("raw:balance_clamped", static_cast<int>(settings.get_balance_clamped()));
+    config.attribute("raw:use_camera_matrix", settings.get_camera_matrix_value());
+    config.attribute("raw:use_camera_wb", static_cast<int>(settings.get_use_camera_wb()));
+    config.attribute("raw:use_auto_wb", static_cast<int>(settings.get_use_auto_wb()));
+    config.attribute("raw:fbdd_noiserd", settings.get_fbdd_noiserd_value());
+
+    // ============================================================
+    // Load via OIIO ImageCache
+    // ============================================================
+    auto buf_result = loadImageBuffer(path, &config);
+    if (!buf_result) {
+        spdlog::error("[SourceManager::loadRawFile]: Failed to load RAW file '{}': {}", path, buf_result.error());
+        return std::unexpected(buf_result.error());
+    }
+
+    // ============================================================
+    // Convert and store
+    // ============================================================
+    m_current_path = path;
+    auto result { convertToRgbaInternal(std::move(buf_result.value())) };
+
+    if (result) {
+        spdlog::info("[SourceManager::loadRawFile]: Loaded '{}': {}x{} RGBA_F32",
+                     path, m_image_buf->spec().width, m_image_buf->spec().height);
+    }
+
+    return result;
+}
+
+std::expected<void, ErrorHandling::CoreError> SourceManager::loadHeicFile(std::string_view path)
+{
+    spdlog::debug("[SourceManager::loadHeicFile]: Processing HEIC file: {}", path);
+
+    // ============================================================
+    // Configure OIIO/libheif with HEIC settings
+    // ============================================================
+    ImageConfig::Heic::HeicSettings settings;
+
+    OIIO::ImageSpec config;
+    config.attribute("oiio:reorient", settings.get_reorient_value());
+    config.attribute("oiio:UnassociatedAlpha", settings.get_unassociated_alpha_value());
+
+    // ============================================================
+    // Load via OIIO ImageCache
+    // ============================================================
+    auto buf_result = loadImageBuffer(path, &config);
+    if (!buf_result) {
+        spdlog::error("[SourceManager::loadHeicFile]: Failed to load HEIC file '{}': {}", path, buf_result.error());
+        return std::unexpected(buf_result.error());
+    }
+
+    // ============================================================
+    // Convert to linear (HEIC from smartphones are typically sRGB)
+    // ============================================================
+    auto [is_linear, cs_name] = Utils::analyzeColorSpace(buf_result->spec());
+
+    if (!is_linear && !cs_name.empty())
+    {
+        auto conversion { Utils::transformToColorSpace(*buf_result, "lin_rec709_scene") };
+        if (!conversion) {
+            spdlog::error("[SourceManager::loadHeicFile]: Color space conversion failed for '{}': {}", path, conversion.error());
+            return std::unexpected(conversion.error());
+        }
+
+    }
+    // ============================================================
+    // Convert and store
+    // ============================================================
+    m_current_path = path;
+    auto result { convertToRgbaInternal(std::move(buf_result.value())) };
+
+    if (result) {
+        spdlog::info("[SourceManager::loadHeicFile]: Loaded '{}': {}x{} RGBA_F32",
+                     path, m_image_buf->spec().width, m_image_buf->spec().height);
+    }
+
+    return result;
+}
+
+std::expected<void, ErrorHandling::CoreError> SourceManager::loadStandardFile(std::string_view path)
+{
+    spdlog::debug("[SourceManager::loadStandardFile]: Processing standard image: {}", path);
+
+    // ============================================================
+    // Load via OIIO ImageCache (no special config)
+    // ============================================================
+    auto buf_result = loadImageBuffer(path, nullptr);
+    if (!buf_result) {
+        spdlog::error("[SourceManager::loadStandardFile]: Failed to load standard file '{}': {}", path, buf_result.error());
+        return std::unexpected(buf_result.error());
+    }
+
+    // ============================================================
+    // Convert to linear if needed
+    // ============================================================
+    auto [is_linear, cs_name] = Utils::analyzeColorSpace(buf_result->spec());
+
+    if (!is_linear && !cs_name.empty())
+    {
+        auto conversion { Utils::transformToColorSpace(*buf_result, "lin_rec709_scene") };
+        if (!conversion) {
+            spdlog::error("[SourceManager::loadStandardFile]: Color space conversion failed for '{}': {}", path, conversion.error());
+            return std::unexpected(conversion.error());
+        }
+
+        auto [is_linear, cs_name] = Utils::analyzeColorSpace(buf_result->spec());
+
+        spdlog::debug("[SourceManager::loadStandardFile]: is linear: '{}' new space: '{}' ",
+                      is_linear, cs_name);
+    }
+
+    // ============================================================
+    // Convert and store
+    // ============================================================
+    m_current_path = path;
+    auto result = convertToRgbaInternal(std::move(buf_result.value()));
+
+    if (result) {
+        spdlog::info("[SourceManager::loadStandardFile]: Loaded '{}': {}x{} RGBA_F32",
+                     path, m_image_buf->spec().width, m_image_buf->spec().height);
+    }
+
+    return result;
+}
+
+std::expected<OIIO::ImageBuf, ErrorHandling::CoreError>
+SourceManager::loadImageBuffer(std::string_view path, const OIIO::ImageSpec* config)
+{
+    if (config)
+    {
+        // Config path: ImageInput::open applies attributes (RAW, HEIF)
+        auto in { OIIO::ImageInput::open(std::string(path), config) };
+        if (!in) {
+            spdlog::error("[SourceManager::loadImageBuffer]: Failed to open '{}': {}", path, OIIO::geterror());
             return std::unexpected(ErrorHandling::CoreError::DecodingError);
         }
 
-        // ============================================================
-        // Step 2: Get dimensions
-        // ============================================================
-        const Common::ImageDim w = static_cast<Common::ImageDim>(src_buf.spec().width);
-        const Common::ImageDim h = static_cast<Common::ImageDim>(src_buf.spec().height);
-        const Common::ImageChan src_ch = static_cast<Common::ImageChan>(src_buf.spec().nchannels);
+        OIIO::ImageSpec float_spec { in->spec() };
+        float_spec.set_format(OIIO::TypeDesc::FLOAT);
 
-        // ============================================================
-        // Step 3: Convert to RGBA_F32 (standard internal format)
-        // ============================================================
-        OIIO::ImageSpec target_spec(static_cast<int>(w), static_cast<int>(h), 4, OIIO::TypeDesc::FLOAT);
-        OIIO::ImageBuf rgba_buf(target_spec);
+        OIIO::ImageBuf buf(float_spec);
 
-        // Channel mapping for conversion
-        std::vector<int> channel_order = {0, 1, 2, 3};
-        std::vector<float> channel_values = {0.0f, 0.0f, 0.0f, 1.0f};
-
-        switch (src_ch) {
-            case 1:  // Grayscale → R=G=B=gray, A=1
-                channel_order = {0, 0, 0, -1};
-                break;
-            case 2:  // Gray+Alpha → RGB=gray, A=alpha
-                channel_order = {0, 0, 0, 1};
-                break;
-            case 3:  // RGB → RGB, A=1
-                channel_order = {0, 1, 2, -1};
-                break;
-            case 4:  // RGBA → direct copy
-            default:
-                channel_order = {0, 1, 2, 3};
-                break;
+        if (!in->read_image(0, 0, 0, -1, OIIO::TypeDesc::FLOAT, buf.localpixels())) {
+            spdlog::error("[SourceManager::loadImageBuffer]: Failed to read '{}': {}", path, in->geterror());
+            return std::unexpected(ErrorHandling::CoreError::DecodingError);
         }
 
-        if (!OIIO::ImageBufAlgo::channels(rgba_buf, src_buf, 4, channel_order, channel_values)) {
-            spdlog::error("[SourceManager::loadFile] Channel conversion failed: {}", rgba_buf.geterror());
-            return std::unexpected(ErrorHandling::CoreError::AllocationFailed);
-        }
-
-        // ============================================================
-        // Step 4: Store final buffer
-        // ============================================================
-        m_image_buf = std::make_unique<OIIO::ImageBuf>(std::move(rgba_buf));
-        m_current_path = path;
-
-        spdlog::info("[SourceManager::loadFile] Loaded '{}': {}x{} RGBA_F32", 
-                     m_current_path, w, h);
-        return {};
-
-    } catch (const std::bad_alloc&) {
-        spdlog::critical("[SourceManager::loadFile] Allocation failed for '{}'", path);
-        m_image_buf.reset();
-        return std::unexpected(ErrorHandling::CoreError::AllocationFailed);
-    } catch (const std::exception& e) {
-        spdlog::critical("[SourceManager::loadFile] Exception: {}", e.what());
-        m_image_buf.reset();
-        return std::unexpected(ErrorHandling::CoreError::Unexpected);
+        in->close();
+        return buf;
     }
+
+    // Standard path: ImageCache
+    OIIO::ImageBuf buf(std::string(path), 0, 0, s_global_cache_ptr);
+    if (!buf.read(0, 0, true, OIIO::TypeDesc::FLOAT)) {
+        spdlog::error("[SourceManager::loadImageBuffer]: Failed to read '{}': {}", path, buf.geterror());
+        return std::unexpected(ErrorHandling::CoreError::DecodingError);
+    }
+
+    return buf;
+}
+
+std::expected<void, ErrorHandling::CoreError> SourceManager::convertToRgbaInternal(OIIO::ImageBuf&& src_buf)
+{
+    // ============================================================
+    // Get dimensions
+    // ============================================================
+    const Common::ImageDim w { static_cast<Common::ImageDim>(src_buf.spec().width) };
+    const Common::ImageDim h { static_cast<Common::ImageDim>(src_buf.spec().height) };
+    const Common::ImageChan src_ch { static_cast<Common::ImageChan>(src_buf.spec().nchannels) };
+
+    spdlog::debug("[SourceManager::convertToRgbaInternal]: {}x{} ({} channels)", w, h, src_ch);
+
+    // ============================================================
+    // Convert to RGBA_F32
+    // ============================================================
+    OIIO::ImageSpec target_spec(static_cast<int>(w), static_cast<int>(h), 4, OIIO::TypeDesc::FLOAT);
+    OIIO::ImageBuf rgba_buf(target_spec);
+
+    std::vector<int> channel_order = {0, 1, 2, 3};
+    std::vector<float> channel_values = {0.0f, 0.0f, 0.0f, 1.0f};
+
+    switch (src_ch)
+    {
+    case 1:  channel_order = {0, 0, 0, -1}; break;
+    case 2:  channel_order = {0, 0, 0, 1}; break;
+    case 3:  channel_order = {0, 1, 2, -1}; break;
+    default: channel_order = {0, 1, 2, 3}; break;
+    }
+
+    if (!OIIO::ImageBufAlgo::channels(rgba_buf, src_buf, 4, channel_order, channel_values)) {
+        spdlog::error("[SourceManager::convertToRgbaInternal]: Channel conversion failed: {}", rgba_buf.geterror());
+        return std::unexpected(ErrorHandling::CoreError::AllocationFailed);
+    }
+
+    // ============================================================
+    // Store final buffer
+    // ============================================================
+    m_image_buf = std::make_unique<OIIO::ImageBuf>(std::move(rgba_buf));
+
+    return {};
 }
 
 void SourceManager::unload()
@@ -143,7 +351,7 @@ void SourceManager::unload()
 void SourceManager::unloadInternal()
 {
     if (m_image_buf && m_image_buf->initialized()) {
-        spdlog::info("[SourceManager] Unloading '{}'", m_current_path);
+        spdlog::debug("[SourceManager::unloadInternal]: Unloading '{}'", m_current_path);
     }
     m_image_buf.reset();
     m_current_path.clear();
@@ -176,7 +384,7 @@ Common::ImageChan SourceManager::channels() const noexcept
 }
 
 std::expected<std::unique_ptr<Common::ImageRegion>, ErrorHandling::CoreError>
-SourceManager::getTile(Common::ImageDim x, Common::ImageDim y, 
+SourceManager::getTile(Common::ImageDim x, Common::ImageDim y,
                        Common::ImageDim width, Common::ImageDim height)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -196,27 +404,27 @@ SourceManager::getTile(Common::ImageDim x, Common::ImageDim y,
         static_cast<int>(y), static_cast<int>(y + height),
         0, 1,
         0, 4
-    );
+        );
 
     // Allocate result
-    const size_t dataSize = static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
-    std::vector<float> data(dataSize);
+    const size_t data_size { static_cast<size_t>(width) * static_cast<size_t>(height) * 4 };
+    std::vector<float> data(data_size);
 
     if (!m_image_buf->get_pixels(roi, OIIO::TypeDesc::FLOAT, data.data())) {
-        spdlog::warn("[SourceManager::getTile] get_pixels failed: {}", m_image_buf->geterror());
+        spdlog::warn("[SourceManager::getTile]: get_pixels failed: {}", m_image_buf->geterror());
         return std::unexpected(ErrorHandling::CoreError::IOError);
     }
 
     // Create ImageRegion
-    auto region = std::make_unique<Common::ImageRegion>(
+    auto region { std::make_unique<Common::ImageRegion>(
         std::move(data),
         width,
         height,
         static_cast<Common::ImageChan>(4)
-    );
+        )};
+
     region->m_x = static_cast<Common::ImageCoord>(x);
     region->m_y = static_cast<Common::ImageCoord>(y);
-    region->m_format = Common::PixelFormat::RGBA_F32;
 
     return region;
 }
@@ -246,7 +454,7 @@ SourceManager::setTile(const Common::ImageRegion& tile)
         static_cast<int>(tile.m_y), static_cast<int>(tile.m_y + tile.m_height),
         0, 1,
         0, 4
-    );
+        );
 
     if (!m_image_buf->set_pixels(roi, OIIO::TypeDesc::FLOAT, tile.m_data.data())) {
         spdlog::error("[SourceManager::setTile] set_pixels failed: {}", m_image_buf->geterror());
@@ -264,8 +472,8 @@ std::optional<std::string> SourceManager::getMetadata(std::string_view key) cons
         return std::nullopt;
     }
 
-    const auto& spec = m_image_buf->spec();
-    const auto* attr = spec.find_attribute(std::string(key));
+    const auto& spec { m_image_buf->spec() };
+    const auto* attr { spec.find_attribute(std::string(key)) };
 
     return attr ? std::optional{attr->get_string()} : std::nullopt;
 }

--- a/core/src/utils/color_space_utils.cpp
+++ b/core/src/utils/color_space_utils.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file color_space_utils.cpp
+ * @brief Implementation of color space analysis and conversion utilities.
+ * @author CaptureMoment Team
+ * @date 2026
+ */
+
+#include "utils/color_space_utils.h"
+
+#include <OpenImageIO/imagebufalgo.h>
+#include <spdlog/spdlog.h>
+
+namespace CaptureMoment::Core::Utils {
+
+std::string getColorSpace(const OIIO::ImageBuf& buf) noexcept
+{
+    const auto cs { buf.spec().get_string_attribute("oiio:ColorSpace") };
+    return cs.empty() ? std::string{} : std::string(cs);
+}
+
+bool isLinearToken(std::string_view colorspace) noexcept
+{
+    if (colorspace.empty()) {
+        return false;
+    }
+
+    // All CIF linear tokens start with "lin_"
+    // Examples: lin_rec709_scene, lin_ap1_scene, lin_ap0_scene, lin_srgb
+    if (colorspace.starts_with("lin_")) {
+        return true;
+    }
+
+    // OCIO role for scene-linear data
+    if (colorspace.starts_with("scene_linear")) {
+        return true;
+    }
+
+    // "Linear" is OIIO's shorthand for lin_rec709_scene
+    if (colorspace == "Linear") {
+        return true;
+    }
+
+    return false;
+}
+
+ColorSpaceInfo analyzeColorSpace(const OIIO::ImageSpec& spec) noexcept
+{
+    const auto cs { spec.get_string_attribute("oiio:ColorSpace") };
+    
+    if (cs.empty()) {
+        return {false, ""};
+    }
+
+    return {isLinearToken(cs), std::string(cs)};
+}
+
+std::expected<void, ErrorHandling::CoreError>
+transformToColorSpace(OIIO::ImageBuf& image, std::string_view target_cs)
+{
+    if (!image.initialized()) {
+        spdlog::warn("[transformToColorSpace]: Buffer is not initialized");
+        return std::unexpected(ErrorHandling::CoreError::InvalidWorkingImage);
+    }
+
+    const std::string source_cs { getColorSpace(image) };
+
+    if (source_cs.empty()) {
+        spdlog::warn("[transformToColorSpace]: No color space metadata found");
+        return std::unexpected(ErrorHandling::CoreError::DecodingError);
+    }
+
+    if (!OIIO::ImageBufAlgo::colorconvert(image, image,
+                                            source_cs,
+                                            std::string(target_cs))) {
+        spdlog::error("[transformToColorSpace]: Conversion from {} to {} failed: {}",
+                      source_cs, target_cs, image.geterror());
+        return std::unexpected(ErrorHandling::CoreError::DecodingError);
+    }
+
+    return {};
+}
+
+} // namespace CaptureMoment::Core::Utils

--- a/core/src/utils/image_conversion.cpp
+++ b/core/src/utils/image_conversion.cpp
@@ -34,15 +34,14 @@ std::unique_ptr<Common::ImageRegion> convert_RGBA_F32_to_RGBA_U8(const Common::I
     }
 
     // 4. Extract U8 data to ImageRegion
-    auto result = std::make_unique<Common::ImageRegion>();
-    result->m_x = input.m_x;
-    result->m_y = input.m_y;
-    result->m_width = input.m_width;
-    result->m_height = input.m_height;
-    result->m_channels = input.m_channels;
-    result->m_format = Common::PixelFormat::RGBA_U8;
+    auto result { std::make_unique<Common::ImageRegion>() };
+    result->m_x = input.x();
+    result->m_y = input.y();
+    result->m_width = input.width();
+    result->m_height = input.height();
+    result->m_channels = input.channels();
 
-    const size_t total_elements = static_cast<size_t>(input.m_width) * input.m_height * input.m_channels;
+    const size_t total_elements { static_cast<size_t>(input.width()) * input.height() * input.channels() };
     result->m_data.resize(total_elements);
 
     if (!dst_buf.get_pixels(OIIO::ROI::All(), OIIO::TypeDesc::UINT8, result->m_data.data())) {

--- a/docs/architecture/CORE_DESIGN.md
+++ b/docs/architecture/CORE_DESIGN.md
@@ -38,15 +38,23 @@ The core functionality is split into specialized components: Managers handle res
 * **Problem:** Implementing image processing logic separately for CPU and multiple GPU APIs (CUDA, OpenCL, Metal, DX12, Vulkan) leads to massive code duplication and maintenance overhead.
 * **Solution:** Introduce the `IWorkingImageHardware` interface. Concrete implementations (`WorkingImageCPU_Halide`, `WorkingImageGPU_Halide` and its descendants like `WorkingImageCUDA_Halide`, `WorkingImageVulkan_Halide`) handle platform-specific details.
 * **Impact:**
-  * **Unified Processing Logic:** Algorithms (like the fused Halide pipeline execution) operate on the `IWorkingImageHardware` interface, oblivious to the underlying hardware.
+  * **Unified Processing Logic:** Algorithms (like the fused Halide pipeline execution and downsampling) operate on the `IWorkingImageHardware` interface, oblivious to the underlying hardware.
   * **Modularity:** Adding a new backend involves implementing the interface, without touching the core processing logic.
   * **Flexibility:** The system can dynamically choose the best backend (`AppConfig`, benchmarking) at runtime or initialization.
+  * **Performance:** The `downsample` method allows efficient generation of display-sized images, potentially leveraging GPU acceleration.
 
 ### `CaptureMoment::Core::ImageProcessing::WorkingImageHalide` (Base Class)
 
 * **Shared Infrastructure**: Base class providing common Halide buffer functionality for both CPU and GPU implementations.
 * **Memory Management**: Uses `std::unique_ptr<float[]>` (allocated via `std::make_unique_for_overwrite`) as backing store for Halide buffers, enabling in-place modifications without unnecessary copies and avoiding zero-initialization overhead during allocation.
 * **Pattern Explanation (Template Method):** Defines common steps for buffer creation and management, allowing subclasses to customize specific parts (e.g., GPU buffer allocation/deallocation).
+
+### `CaptureMoment::Core::ImageProcessing::WorkingImageData` (Base Class)
+
+*   **Raw Data Storage**: Provides the underlying `std::unique_ptr<float[]>` (`m_data`) and metadata (`m_width`, `m_height`, `m_channels`, `m_valid`) for CPU and GPU implementations.
+*   **Common Types**: Uses `Common::ImageDim`, `Common::ImageChan`, `Common::ImageSize` for its members.
+*   **Initialization Logic**: Contains the `initializeData` method, which handles the allocation and copying of pixel data from an `ImageRegion`, and sets the metadata.
+*   **State Management**: The `m_valid` flag is managed here and used by derived classes to determine the overall validity state.
 
 ### WorkingImage Refactoring
 
@@ -69,7 +77,7 @@ This factory encapsulates the logic for creating the appropriate `IWorkingImageH
 * **Impact:**
   * **Performance:** Dramatically reduces execution time by minimizing memory bandwidth usage and loop overhead.
   * **Quality:** Reduces cumulative floating-point errors by performing all calculations in a single pass.
-  * **Hardware Agnostic:** The seamlessly across different hardware backends.
+  * **Hardware Agnostic:** The fused pipeline system works seamlessly across different hardware backends.
 
 ### Operation Fusion Logic Update
 
@@ -137,7 +145,7 @@ This factory encapsulates the logic for creating the appropriate `IWorkingImageH
 
 * **Pattern Explanation (Facade):** `FileSerializerManager` provides a simplified interface to the complex serialization subsystem (`IXmpProvider`, `IXmpPathStrategy`, `IFileSerializerWriter/Reader`).
 
-* **Usage:** ReFloat`, `serializeDouble`, etc., within the serialization module and other parts of the core requiring type-to-string conversion.
+* **Usage:** Relies on `CaptureMoment::Core::Serializer::OperationSerialization` for parameter conversion, which in turn uses generic conversion utilities from `CaptureMoment::Core::utils`.
 
 ---
 
@@ -147,6 +155,7 @@ This factory encapsulates the logic for creating the appropriate `IWorkingImageH
 * **Solution:**
   * Use `std::span<float>` for non-owning views of data, minimizing copies when passing buffers to algorithms (like Halide).
   * Use `std::unique_ptr<float[]>` with `std::make_unique_for_overwrite` for owning allocations (e.g., in `WorkingImageHalide`), avoiding zero-initialization overhead for large buffers that are immediately filled.
+  * Use move semantics (`std::move`) for transferring ownership of large objects like `std::vector` or `ImageRegion` between functions/components.
 * **Impact:**
   * **Performance:** Reduces allocation time and memory bandwidth usage.
   * **Safety:** RAII and smart pointers prevent leaks.
@@ -172,6 +181,7 @@ This factory encapsulates the logic for creating the appropriate `IWorkingImageH
 * **Optimized Scheduling:** Pipeline fusion creates single computational passes instead of multiple sequential operations.
 * **Backend Selection:** Runtime benchmarking automatically determines optimal CPU/GPU usage.
 * **Pipeline Fusion Optimization:** Fused Execution: Operations now support both sequential (`execute`) and fused (`appendToFusedPipeline`) execution patterns.
+* **Hardware-Accelerated Downsampling:** The `IWorkingImageHardware::downsample` method allows generating display-sized images efficiently, potentially on the GPU.
 
 ---
 
@@ -181,7 +191,7 @@ This factory encapsulates the logic for creating the appropriate `IWorkingImageH
 * **Solution:**
   * `StateImageManager` acts as the single authority for the current "working image".
   * Operations modify the image *in-place* on the `IWorkingImageHardware` managed by `WorkingImageContext`.
-  * Explicit synchronization points (e.g., waiting on futures from workers) ensure operations complete before dependent actions begin.
+  * Explicit synchronization points (e.g., waiting on futures from `PhotoEngine::applyOperations`) ensure operations complete before dependent actions begin.
 * **Impact:**
   * **Clarity:** Clear ownership and modification points.
   * **Consistency:** Ensures the displayed or saved image reflects the latest applied operations.
@@ -192,7 +202,7 @@ This factory encapsulates the logic for creating the appropriate `IWorkingImageH
 
 * **Unit Tests:** Individual components (Operations, Factories, Utils) are tested in isolation using mocks for dependencies.
 * **Integration Tests:** Higher-level workflows (e.g., `StateImageManager::applyOperations`) are tested with real or near-real dependencies.
-* **Performance Tests:** Benchmark critical paths (pipeline execution, loading times) to monitor regressions.
+* **Performance Tests:** Benchmark critical paths (pipeline execution, loading times, downsampling) to monitor regressions.
 
 ---
 
@@ -208,22 +218,23 @@ This factory encapsulates the logic for creating the appropriate `IWorkingImageH
 
 The codebase is structured using a clear namespace hierarchy to improve modularity and maintainability:
 
-- **`CaptureMoment::Core::Common`**: Contains fundamental data structures like `ImageRegion` and `PixelFormat`.
+- **`CaptureMoment::Core::Common`**: Contains fundamental data structures like `ImageRegion` and `PixelFormat`, and common types (`ImageTypes`).
 - **`CaptureMoment::Core::Engine`**: Contains the main orchestrator `PhotoEngine`.
 - **`CaptureMoment::Core::Managers`**: Contains resource managers like `StateImageManager`, `SourceManager`.
 - **`CaptureMoment::Core::Operations`**: Contains operation logic and descriptors.
 - **`CaptureMoment::Core::Factories`**: Contains factory classes like `OperationFactory`.
-- **`CaptureMoment::Core::ImageProcessing`**: Contains image buffer abstractions (`IWorkingImageHardware`) and processing helpers.
+- **`CaptureMoment::Core::ImageProcessing`**: Contains image buffer abstractions (`IWorkingImageHardware`, `WorkingImageData`, `WorkingImageHalide`) and processing helpers.
 - **`CaptureMoment::Core::Pipeline`**: Contains pipeline fusion and execution logic (`IPipelineExecutor`, `PipelineContext`).
 - **`CaptureMoment::Core::Strategies`**: Contains high-level processing strategies (`IPipelineManager`).
 - **`CaptureMoment::Core::Workers`**: Contains asynchronous processing workers (`IWorkerRequest`).
-- **`CaptureMoment::Core::Serialization`**: Contains serialization/deserialization logic (`FileSerializerManager`).
+- **`CaptureMoment::Core::Serialization`**: Contains serialization/deserialization logic (`FileSerializerManager`, `OperationSerialization`).
+- **`CaptureMoment::Core::utils`**: Contains generic utility functions (`toString`, `ImageConversion`).
 
 ---
 
 ### StateImageManager as Central Coordinator
 
-- **Exclusive Source Management:** `StateImageManager` now owns and manages `SourceManager` internally, providing a unified interface for image loading (`loadImage`), committing results (`commitWorkingImageToSource`), and querying source properties (`getWidth`, `getHeight`).
+- **Exclusive Source Management:** `StateImageManager` now owns and manages `SourceManager` internally, providing a unified interface for image loading (`loadImage`), committing results (`commitWorkingImageToSource`), and querying source properties (`getWidth`, `getHeight`, `getChannels`).
 - **Simplified PhotoEngine:** `PhotoEngine` delegates image loading and metadata queries to `StateImageManager`.
 
 ---
@@ -270,7 +281,7 @@ The codebase is structured using a clear namespace hierarchy to improve modulari
 - **Problem:** Displaying high-resolution images efficiently required CPU-side downsampling, which could be a bottleneck. The UI layer (`DisplayManager`) previously handled this itself, tightly coupling display logic with image processing details.
 - **Solution:** The `IWorkingImageHardware` interface (and its implementations like `WorkingImageCPU_Halide`, `WorkingImageGPU_Halide`) now exposes a dedicated `downsample(target_width, target_height)` method. This abstracts the *downsampling* operation behind the hardware abstraction layer.
 - **Impact:**
-  * **Core Integration:** The Core's `StateImageManager` and `Engine` now expose a new method `getDownsampledDisplayImage(width, height)`. `StateImageManager` delegates this call to `WorkingImageContext::getDownsampled` (renamed from `downsample` for clarity), which in turn invokes the `downsample` method on the active `IWorkingImageHardware` implementation.
+  * **Core Integration:** The Core's `StateImageManager` and `PhotoEngine` now expose a new method `getDownsampledDisplayImage(width, height)`. `StateImageManager` delegates this call to `WorkingImageContext::getDownsampled` (renamed from `downsample` for clarity), which in turn invokes the `downsample` method on the active `IWorkingImageHardware` implementation.
   * **UI Decoupling:** The `PhotoEngine` serves as the primary entry point for the UI layer (`ImageControllerBase`) to request a display-ready, downsampled image. `ImageControllerBase` calls `m_engine->getDownsampledDisplayImage(...)` and receives the result (as `std::unique_ptr<Common::ImageRegion>`), which it then passes to the `DisplayManager`. This cleanly separates the Core's processing responsibilities from the UI's display management.
   * **Performance:** For GPU implementations (`WorkingImageGPU_Halide`), this means the downsampling operation can be performed *directly on the GPU* using a specialized Halide pipeline before the smaller result buffer is transferred back to the CPU. This drastically reduces the amount of data transferred over the PCIe bus compared to transferring the full-resolution image and downsampling it on the CPU, leading to smoother UI interactions.
   * **Quality:** The CPU-side implementation (`WorkingImageCPU`) was also refined to use `OIIO::ImageBufAlgo::resize` (Lanczos3 filter) instead of `OIIO::ImageBufAlgo::resample` (bilinear), improving the visual quality of CPU-based downsampling.
@@ -334,6 +345,8 @@ The core library includes a flexible system for saving and loading the state of 
 
 * **`CaptureMoment::Core::Serializer::IFileSerializerReader/Writer`:** Interfaces for reading/writing the list of `OperationDescriptor`s from/to the XMP structure.
 
+* **`CaptureMoment::Core::Serializer::OperationSerialization`:** A namespace containing utility functions (`serializeParameter`, `deserializeParameter`) for converting `std::any` (or `std::variant`) parameter values within `OperationDescriptor` to/from string representations suitable for storage in XMP metadata, preserving type information. This module relies on **generic conversion utilities** from the `CaptureMoment::Core::utils` namespace.
+
 ### Benefits
 
 * **Flexibility:** The serialization layer (`FileSerializerManager`) can be managed and invoked independently by the UI layer (e.g., via `UISerializerManager` in the Qt module) without requiring `PhotoEngine` to hold a reference to it.
@@ -366,6 +379,7 @@ This interface represents an image used as a working buffer, abstracting its har
   * `exportToCPUCopy()`: Creates a CPU copy of the image data for display or saving.
   * `updateFromCPU(const ImageRegion&)`: Updates the working buffer from CPU data.
   * `isValid()`: Checks if the buffer is valid.
+  * `downsample(target_width, target_height)`: Generates a downsampled version of the image, potentially on the GPU.
 
 * **`WorkingImageGPU_Halide`**: Concrete implementation inheriting from `IWorkingImageGPU` and `WorkingImageHalide`. Combines GPU-specific logic (device transfers), raw data management (`WorkingImageData`), and Halide buffer logic (`WorkingImageHalide`).
 
@@ -380,5 +394,6 @@ This interface represents an image used as a working buffer, abstracting its har
 
 * **`CaptureMoment::Core::Utils::ToStringConverter`**: A utility class using templates and `std::format` to provide a generic `toString` function for various types (e.g., enums like `CoreError`, floats, doubles, ints). This replaces multiple hand-written serialization functions within the core, promoting code reuse and consistency.
 
+* **`CaptureMoment::Core::utils::toString`**: A generic template function using C++20 Concepts (`ToStringablePrimitive`) for converting primitive types (int, float, double, bool) and strings to their string representation.
+
 * **Usage:** Replaces legacy specific functions like `serializeFloat`, `serializeDouble`, etc., within the serialization module and other parts of the core requiring type-to-string conversion.
-  

--- a/docs/architecture/UI_CORE_ARCHITECTURE.md
+++ b/docs/architecture/UI_CORE_ARCHITECTURE.md
@@ -37,7 +37,7 @@ This architecture manages the Qt/C++ abstraction layer located between the centr
 *   **Responsibilities:**
     *   Maintain the full list of active operations (as `OperationDescriptor`).
     *   Provide thread-safe methods to add, update, remove operations in this state.
-    * to retrieve the full list of active operations.
+    *   Provide a method to retrieve the full list of active operations.
     *   **Does not communicate directly** with `PhotoEngine` or handle serialization.
 
 ### 4. `BaseAdjustmentModel` (and derivatives like `BrightnessModel`)
@@ -53,8 +53,8 @@ This architecture manages the Qt/C++ abstraction layer located between the centr
 
 *   **Role:** Manage display-side logic: viewport-aware downsampling, zoom, pan, tile updates.
 *   **Responsibilities:**
-    *   **Pre-commit `26bf511`:** Managed its own downsampling logic using OIIO, held a reference to the source image, and calculated display size.
-    *   **Post-commit `26bf511` & `94b0f21`:** **No longer** performs local downsampling. Delegates this responsibility entirely to the Core (`IWorkingImageHardware::downsample`). Manages zoom and pan state. Sends display-ready images (received from `ImageControllerBase`) to the appropriate Qt Quick rendering item (`RHIImageItem`, `SGSImageItem`, etc.). Notifies the Core layer of the source image size via `setSourceImageSize`. Implements the `fitToView` logic using the *displayed* image size (`m_display_image_size`) rather than just the source size.
+    *   Managed its own downsampling logic using OIIO, held a reference to the source image, and calculated display size.
+    *   **No longer** performs local downsampling. Delegates this responsibility entirely to the Core (`IWorkingImageHardware::downsample`). Manages zoom and pan state. Sends display-ready images (received from `ImageControllerBase`) to the appropriate Qt Quick rendering item (`RHIImageItem`, `SGSImageItem`, etc.). Notifies the Core layer of the source image size via `setSourceImageSize`. Implements the `fitToView` logic using the *displayed* image size (`m_display_image_size`) rather than just the source size.
     *   **Signature Change:** Methods `createDisplayImage` and `updateDisplayTile` now accept `std::unique_ptr<Core::Common::ImageRegion>`.
     *   **Post-commit `features/viewport`:** Integrates `ViewportManager` (`m_viewport_manager`). The `initialize` method is added to configure the `ViewportManager` with screen and viewport details. The `setSourceImageSize` method now uses `m_viewport_manager->calculateDisplay(...)` to determine the required *downsampled* size, emitting `displayImageRequest` if downsampling is needed. The `downsampleSize` and `maxDownsample` are exposed as QML properties. The `fitToView` and `setViewportSize` methods utilize calculations from the `ViewportManager`. A new method `setQualityMargin` is added to control the quality vs. performance trade-off via the `ViewportManager`.
     *   [🟦 **SEE VIEWPORT_MANAGEMENT.md**](ui/VIEWPORT_MANAGEMENT.md). 
@@ -76,8 +76,8 @@ This architecture manages the Qt/C++ abstraction layer located between the centr
     *   `IRenderingItemBase`: Abstract interface defining common methods (`setImage`, `updateTile`, `setZoom`, `setPan`) and state. **Post-commit `533b85c`:** No longer holds state members like `m_full_image`, `m_zoom`, `m_pan`, etc. Signature of `setImage` and `updateTile` changed to accept `std::unique_ptr<Core::Common::ImageRegion>`. `getFullImage()` now returns a raw pointer `const ImageRegion*`. `zoom()`, `pan()`, `getImageMutex()` are now pure virtual.
     *   `BaseImageItem`: Provides common implementations for `imageWidth`, `imageHeight`, `isImageValid`, `zoom()`, `pan()`, `getImageMutex()`, `getFullImage()`, inheriting from `IRenderingItemBase`. **Post-commit `058c558`:** Holds common state members (`m_full_image`, `m_image_mutex`, `m_zoom`, `m_pan`) as `protected`. Implements virtual handlers `onZoomChanged`, `onPanChanged`, `onImageChanged` for derived classes.
     *   `RHIImageItem`: Uses `QQuickRhiItem` to leverage QRhi (Vulkan, Metal, DirectX12). Integrates `RHIImageNode` for direct manipulation of the render pipeline. **Post-commits `8cb418e`/`1314bd1`:** Signatures updated for `std::unique_ptr`. Implements `onZoomChanged`, `onPanChanged`, `onImageChanged` to emit signals and trigger updates. `RHIImageItemRenderer` is declared as a `friend`.
-    *   `SGSImageItem`: Uses `QQuickItem` and `QSGSimpleTextureNode` via the Scene Graph. **Post-commit `45f2117`:** Signatures updated for `std::unique_ptr`. Implements `onZoomChanged`, `onPanChanged`, `onImageChanged`. Optimized tile update logic.
-    *   `PaintedImageItem`: Uses `QQuickPaintedItem` and `QPainter`. **Post-commit `7bebceb`:** Signatures updated for `std::unique_ptr`. Implements `onZoomChanged`, `onPanChanged`, `onImageChanged`. Optimized tile update logic (treated as full replacement).
+    *   `SGSImageItem`: Uses `QQuickItem` and `QSGSimpleTextureNode` via the Scene Graph. **Post-commit `45f2117`:** Signatures updated for `std::unique_ptr`. Implements `onZoomChanged`, `onPanChanged`, `onImageChanged`. Optimized tile update logic. **Post-commit `features/raws` (`0db5f909`):** When updating the paint node, the internal linear F32 image data (from `m_full_image`) is interpreted using `QImage::Format_RGBA32FPx4`, assigned the `QColorSpace::SRgbLinear` color space, and then converted to `QImage::Format_RGBA8888` with the standard `QColorSpace::SRgb` for display, leveraging Qt's color space conversion utilities.
+    *   `PaintedImageItem`: Uses `QQuickPaintedItem` and `QPainter`. **Post-commit `7bebceb`:** Signatures updated for `std::unique_ptr`. Implements `onZoomChanged`, `onPanChanged`, `onImageChanged`. Optimized tile update logic (treated as full replacement). **Post-commit `features/raws` (`106b57d6`):** The `convertImageRegionToQImage` utility method now interprets the linear F32 image data (from `ImageRegion`) using `QImage::Format_RGBA32FPx4`, assigns the `QColorSpace::SRgbLinear` color space, and then converts it to `QImage::Format_RGBA8888` with the standard `QColorSpace::SRgb` for drawing with `QPainter`, leveraging Qt's color space conversion utilities.
     *   All concrete items inherit from their specific Qt Quick base (`QQuickRhiItem`, `QQuickItem`, `QQuickPaintedItem`) and from `BaseImageItem` to get common state and logic.
     *   Receive the updated image from `DisplayManager` and display it.
     *   Implement zoom and pan logic.
@@ -103,7 +103,7 @@ This architecture manages the Qt/C++ abstraction layer located between the centr
 
 ## 🧩 Flow Diagrams
 
-### A. Image Processing Flow (updated for hardware abstraction, fused pipelines, and viewport management, post `features/viewport`)
+### A. Image Processing Flow (updated for hardware abstraction, fused pipelines, viewport management, and Qt color space handling, post `features/raws`)
 
 1.  **Initialization:** `QmlContextSetup` creates `ImageControllerBase`, which creates its dependencies (`OperationStateManager`, `OperationModelManager`, `DisplayManager`, etc.). `OperationModelManager` creates the models, and `ImageControllerBase` connects them to `OperationStateManager`. `DisplayManager` is initialized (e.g., via `DisplayManager::initialize`) with viewport and screen information, which configures its internal `ViewportManager`.
 2.  **QML Interaction:** A user moves a slider (e.g., Brightness). This calls `brightnessControl.setValue(newValue)` in QML.
@@ -113,8 +113,8 @@ This architecture manages the Qt/C++ abstraction layer located between the centr
 6.  **Core Call:** `ImageControllerBase::doApplyOperations` calls `PhotoEngine::applyOperations(full_list_of_operations)`.
 7.  **Processing in Core:** `PhotoEngine` delegates to `StateImageManager` (Core) which uses `OperationPipelineBuilder` to create an `OperationPipelineExecutor`. This executor applies the list of operations via **fused Halide pipeline execution** using the hardware-agnostic `IWorkingImageHardware` abstraction (`WorkingImageCPU_Halide` or `WorkingImageGPU_Halide`). The dynamic input buffer binding ensures the correct image data is processed by the fused pipeline.
 8.  **Display Update (Core -> UI):** `ImageControllerBase::doApplyOperations` (or `doLoadImage`) calls `m_engine->getDownsampledDisplayImage(target_width, target_height)`. The `target_width` and `target_height` are now obtained from `m_display_manager->downsampleSize()`, which was calculated by the `DisplayManager`'s `ViewportManager` based on the source image size and viewport characteristics.
-9.  **Display Update (UI Propagation):** `ImageControllerBase` receives the downsampled image (as `std::unique_ptr<Core::Common::ImageRegion>`) and passes it (via `std::move`) to `m_display_manager->createDisplayImage(...)` (or `updateDisplayTile(...)` depending on the flow, though `createDisplayImage` is used in `doApplyOperations` as per the latest changes).
-10. **Display Update (UI Rendering):** `DisplayManager` receives the image and passes it (via `std::move`) to the Qt Quick rendering item (e.g., `RHIImageItem::setImage`) for display.
+9.  **Display Update (UI Propagation):** `ImageControllerBase` receives the downsampled image (as `std::unique_ptr<Core::Common::ImageRegion`) and passes it (via `std::move`) to `m_display_manager->createDisplayImage(...)` (or `updateDisplayTile(...)` depending on the flow, though `createDisplayImage` is used in `doApplyOperations` as per the latest changes).
+10. **Display Update (UI Rendering):** `DisplayManager` receives the image and passes it (via `std::move`) to the Qt Quick rendering item (e.g., `RHIImageItem::setImage`) for display. **Post-commit `features/raws`:** Items like `SGSImageItem` and `PaintedImageItem` now use Qt's `QColorSpace` utilities to correctly convert the linear F32 image data received from the Core to the standard sRGB color space expected for display on screen.
 
 ### B. Serialization Flow (unchanged)
 1.  **Initialization:** `QmlContextSetup` receives an instance of `SerializerController` (created elsewhere) and registers it to the QML context as `serializerController`.
@@ -124,4 +124,3 @@ This architecture manages the Qt/C++ abstraction layer located between the centr
 5.  **QML Response:** QML listens to these signals and updates the UI accordingly (e.g., show a success message, apply loaded operations to the `OperationStateManager`).
 
 ---
-

--- a/qt/core/src/rendering/painted_image_item.cpp
+++ b/qt/core/src/rendering/painted_image_item.cpp
@@ -8,6 +8,7 @@
 #include "rendering/painted_image_item.h"
 #include <spdlog/spdlog.h>
 #include <QPainter>
+#include <QColorSpace>
 #include <QMutexLocker>
 #include <algorithm>
 
@@ -90,19 +91,17 @@ QImage PaintedImageItem::convertImageRegionToQImage(const Core::Common::ImageReg
 
     const int w { static_cast<int>(region.width()) };
     const int h { static_cast<int>(region.height()) };
-    const int ch { region.channels() };
 
-    QImage::Format format { (ch == 4) ? QImage::Format_RGBA8888 : QImage::Format_RGB888 };
-    QImage qimg(w, h, format);
+    QImage linear_img(
+        reinterpret_cast<const uchar*>(region.m_data.data()),
+        w, h,
+        w * 4 * static_cast<int>(sizeof(float)),
+        QImage::Format_RGBA32FPx4
+        );
+    linear_img.setColorSpace(QColorSpace(QColorSpace::SRgbLinear));
 
-    const float* src { region.m_data.data() };
-    uchar* dst = qimg.bits();
-
-    for (int i = 0; i < w * h * ch; ++i) {
-        dst[i] = static_cast<uchar>(std::clamp(src[i], 0.0f, 1.0f) * 255.0f);
-    }
-
-    return qimg;
+    return linear_img.convertedToColorSpace(QColorSpace(QColorSpace::SRgb))
+        .convertToFormat(QImage::Format_RGBA8888);
 }
 
 bool PaintedImageItem::isImagePaintValid() const

--- a/qt/core/src/rendering/sgs_image_item.cpp
+++ b/qt/core/src/rendering/sgs_image_item.cpp
@@ -14,12 +14,13 @@
 #include <QImage>
 #include <algorithm>
 #include <cstring>
+#include <QColorSpace>
 
 namespace CaptureMoment::UI::Rendering {
 
 // Constructor: Initializes the item and sets the flag for custom content.
 SGSImageItem::SGSImageItem(QQuickItem* parent)
-    : QQuickItem(parent) // Appel du constructeur de QQuickItem
+    : QQuickItem(parent)
 {
     // Indicate to Qt Quick that this item has custom content rendered via the scene graph.
     setFlag(QQuickItem::ItemHasContents, true);
@@ -78,7 +79,8 @@ void SGSImageItem::updateTile(std::unique_ptr<Core::Common::ImageRegion> tile)
 
         // Full replacement if same dimensions (most common case)
         if (tile->width() == m_full_image->width() &&
-            tile->height() == m_full_image->height()) {
+            tile->height() == m_full_image->height())
+        {
             // Copy data instead of move to avoid destructor issues
             const size_t data_size { tile->width() * tile->height() * tile->channels() };
             std::copy(tile->getBuffer().data(),
@@ -86,7 +88,8 @@ void SGSImageItem::updateTile(std::unique_ptr<Core::Common::ImageRegion> tile)
                       m_full_image->getBuffer().data());
             m_image_dirty = true;
             spdlog::info("[SGSImageItem::updateTile]: Full copy {}x{}", tile->width(), tile->height());
-        } else {
+        } else
+        {
             // Partial tile update
             if (tile->x() < 0 || tile->y() < 0 ||
                 tile->x() + tile->width() > m_full_image->width() ||
@@ -102,7 +105,8 @@ void SGSImageItem::updateTile(std::unique_ptr<Core::Common::ImageRegion> tile)
             const int tile_y { tile->y() } ;
             const int tile_h { static_cast<int>(tile->height()) };
 
-            for (int y = 0; y < tile_h; ++y) {
+            for (size_t y = 0; y < tile_h; ++y)
+            {
                 const float* src = tile->getBuffer().data() + y * row_size;
                 // FIXED: (tile_y + y) not (tile_x + y)
                 float* dst = m_full_image->getBuffer().data() +
@@ -124,73 +128,65 @@ QSGNode* SGSImageItem::updatePaintNode(QSGNode* node, UpdatePaintNodeData* data)
 {
     Q_UNUSED(data);
 
-    // Early exit if no valid image
     if (!isImageValid()) {
-        // Return existing node or nullptr
         return node;
     }
 
     auto* texture_node { static_cast<QSGSimpleTextureNode*>(node) };
 
-    // Cache dimensions BEFORE acquiring mutex to avoid nested locks
-    // (imageWidth()/imageHeight() also acquire the mutex)
-    int img_w {0};
-    int img_h {0};
-    bool needs_texture_update {false};
+    int img_w { 0 };
+    int img_h { 0 };
+    bool needs_texture_update { false };
     QImage new_qimage;
 
     {
         QMutexLocker lock(&m_image_mutex);
 
-        if (m_full_image && m_full_image->isValid()) {
+        if (m_full_image && m_full_image->isValid())
+        {
             img_w = static_cast<int>(m_full_image->width());
             img_h = static_cast<int>(m_full_image->height());
 
-            if (m_image_dirty) {
+            if (m_image_dirty)
+            {
                 needs_texture_update = true;
 
-                // Create QImage while holding the lock
-                const int ch { m_full_image->channels() };
-                QImage::Format format { (ch == 4) ? QImage::Format_RGBA8888 : QImage::Format_RGB888 };
-                new_qimage = QImage(img_w, img_h, format);
+                QImage linear_img(
+                    reinterpret_cast<const uchar*>(m_full_image->getBuffer().data()),
+                    img_w, img_h,
+                    img_w * 4 * static_cast<int>(sizeof(float)),
+                    QImage::Format_RGBA32FPx4
+                    );
 
-                const float* src { m_full_image->getBuffer().data() };
-                uchar* dst { new_qimage.bits() };
+                const QColorSpace linear_cs { QColorSpace::SRgbLinear };
+                linear_img.setColorSpace(linear_cs);
 
-                for (int i = 0; i < img_w * img_h * ch; ++i) {
-                    dst[i] = static_cast<uchar>(std::clamp(src[i], 0.0f, 1.0f) * 255.0f);
-                }
+                new_qimage = linear_img.convertedToColorSpace(QColorSpace::SRgb)
+                                 .convertToFormat(QImage::Format_RGBA8888);
 
                 m_image_dirty = false;
             }
         }
     }
 
-    // Check if window is valid (item must be in a window)
     QQuickWindow* win = window();
     if (!win) {
         spdlog::warn("[SGSImageItem::updatePaintNode]: No window attached");
         return node;
     }
 
-    // Create new node if needed
     if (!texture_node) {
         texture_node = new QSGSimpleTextureNode();
     }
 
-    // Update texture if needed
-    // NOTE: We create a NEW texture instead of deleting the old one
-    // The old texture will be cleaned up by Qt's scene graph when the node is removed
-    // or when we set a new texture with proper ownership
-    if (needs_texture_update && !new_qimage.isNull()) {
-        // Create texture from image (this is thread-safe with Qt's scene graph)
+    if (needs_texture_update && !new_qimage.isNull())
+    {
         QSGTexture* new_texture { win->createTextureFromImage(
             new_qimage,
             QQuickWindow::TextureHasAlphaChannel
             ) };
 
         if (new_texture) {
-            // Set the new texture - the node takes ownership
             texture_node->setTexture(new_texture);
             texture_node->setOwnsTexture(true);
         } else {
@@ -198,9 +194,8 @@ QSGNode* SGSImageItem::updatePaintNode(QSGNode* node, UpdatePaintNodeData* data)
         }
     }
 
-    // Update geometry if we have a valid texture
-    if (texture_node->texture()) {
-        // Use cached dimensions (img_w/img_h if updated, otherwise query base class)
+    if (texture_node->texture())
+    {
         float display_w, display_h;
         if (img_w > 0 && img_h > 0) {
             display_w = img_w * m_zoom;


### PR DESCRIPTION
This PR establishes a dedicated framework for configuring image input formats (RAW, HEIC) and significantly improves color space management during the image loading process. It refines the internal processing contract to a standardized linear F32 format and integrates Qt's color space utilities for final display output.

### 🔧 Changelog

#### Core Library (`Core`)
*   **Introduce Image Configuration (`ImageConfig`):**
    *   Added `RawSettings` structure for centralized, runtime-configurable RAW development parameters (demosaic, color space, highlights, etc.) with preset factories (fast, performance, quality).
    *   Added `HeicSettings` structure for centralized, runtime-configurable HEIF/HEIC/AVIF loading parameters (reorientation, alpha mode) with preset factories.
    *   Added umbrella header `image_config.h` to aggregate these new settings.
*   **Introduce Color Space Utilities (`Utils`):**
    *   Added `ColorSpaceUtils` (`color_space_utils.h/cpp`) for analyzing (detecting linear spaces) and converting (via OIIO) image color spaces based on metadata.
*   **Refine Internal Processing Contract (`Common`):**
    *   Updated `PixelFormat` to exclusively define F32 formats (`RGB_F32`, `RGBA_F32`), removing U8/U16 variants.
    *   Updated `ImageRegion` constructor to default to `PixelFormat::RGBA_F32`.
    *   Simplified `getChannelCount` and `getPixelSizeInBytes` in `pixel_format.h` to reflect the F32-only contract.
*   **Enhance `SourceManager` (`Managers`):**
    *   Implemented type-specific loading logic (`loadRawFile`, `loadHeicFile`, `loadStandardFile`) dispatched from `loadFile`.
    *   Integrated `RawSettings` and `HeicSettings` to configure OIIO/LibRaw and OIIO/libheif appropriately during loading.
    *   Integrated `ColorSpaceUtils` to automatically detect and convert non-linear input images (e.g., sRGB JPEG/HEIC) to a linear working space (`lin_rec709_scene`) upon loading.
    *   Added `loadImageBuffer` helper for raw OIIO loading with optional configuration.
    *   Updated `convertToRgbaInternal` to align with the F32-only contract.
    *   Improved error handling with `std::formatter` specialization for `CoreError`.
*   **Add Umbrella Header (`Utils`):** Introduced `utils.h` as an umbrella header for utility modules.
*   **Update CMake/PCH:** Updated `CMakeLists.txt` and `pch.h` to include new headers (`utils.h`, `image_config.h`, `magic_enum`).

#### UI Core Library (`Qt::Core`)
*   **Integrate Qt Color Space Conversion (`Rendering`):**
    *   Modified `SGSImageItem::updatePaintNode` to interpret the linear F32 data from `m_full_image` using `QImage::Format_RGBA32FPx4`, assign `QColorSpace::SRgbLinear`, and convert to `QImage::Format_RGBA8888` with `QColorSpace::SRgb` for display.
    *   Modified `PaintedImageItem::convertImageRegionToQImage` to interpret the linear F32 data from `ImageRegion` using `QImage::Format_RGBA32FPx4`, assign `QColorSpace::SRgbLinear`, and convert to `QImage::Format_RGBA8888` with `QColorSpace::SRgb` for painting.

#### Documentation (`docs`)
*   **Update `CORE_DESIGN.md`:** Reflects changes related to the refined processing contract and color space handling.
*   **Update `UI_CORE_ARCHITECTURE.md`:** Documents the integration of Qt color space utilities in the rendering components.


### 🚨 Notes

*   The Core's internal processing contract is now strictly F32 formats.
*   Color space conversions rely on OIIO's metadata detection and `ColorSpaceUtils` for initial linearization. Full OpenColorIO integration remains a future goal.
*   Qt's `QColorSpace` is now utilized in the UI rendering layer for the final conversion from the linear internal format to the display format.