### PR TITLE
Features/cpm  : [Build] Migrate spdlog & magic_enum to CPM (CMake Package Manager)

### DIFF
--- a/.github/workflows/macos_brew.yml
+++ b/.github/workflows/macos_brew.yml
@@ -45,7 +45,7 @@
             brew install halide 
             brew install exiv2
             
-            brew list --versions spdlog openimageio halide exiv2 magic_enum
+            brew list --versions openimageio halide exiv2
 
       # ====================================================================
       # Setup Qt

--- a/.github/workflows/macos_brew.yml
+++ b/.github/workflows/macos_brew.yml
@@ -41,14 +41,9 @@
           run: |
             brew update
             brew upgrade cmake
-            brew install spdlog
             brew install openimageio
             brew install halide 
             brew install exiv2
-            brew install magic_enum
-
-            # Optional: Halide (if available in homebrew)
-            # brew install halide
             
             brew list --versions spdlog openimageio halide exiv2 magic_enum
 

--- a/.github/workflows/macos_brew.yml
+++ b/.github/workflows/macos_brew.yml
@@ -41,11 +41,15 @@
           run: |
             brew update
             brew upgrade cmake
+            brew install spdlog
             brew install openimageio
             brew install halide 
             brew install exiv2
+
+            # Optional: Halide (if available in homebrew)
+            # brew install halide
             
-            brew list --versions openimageio halide exiv2
+            brew list --versions spdlog openimageio halide exiv2
 
       # ====================================================================
       # Setup Qt

--- a/cmake/PackageHelpers.cmake
+++ b/cmake/PackageHelpers.cmake
@@ -16,18 +16,12 @@ endif()
 include("${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
 message(STATUS "Using CPM.cmake from: ${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
 
-# for fmt, we want to use the header-only version to avoid linking issues
-add_compile_definitions(FMT_HEADER_ONLY=1)
-
 # ============================================================
 # Find all required packages
 # ============================================================
 function(find_required_packages)
-    # spdlog (mandatory) via CPM
+    # spdlog (mandatory)
     find_spdlog_package()
-
-    # magic_enum (mandatory) via CPM
-    find_magic_enum_package()
 
     # OpenImageIO (mandatory)
     find_openimageio_package()
@@ -38,7 +32,11 @@ function(find_required_packages)
     # Exiv2 (mandatory for serialization)
     find_exiv2_package()
 
+    # magic_enum (mandatory)
+    find_magic_enum_package()
+    
     # Qt6 will be searched by the sub-projects ui/desktop, ui/mobile
+
     summarize_found_packages()
     warn_halide_requirements()
 endfunction()
@@ -48,43 +46,24 @@ endfunction()
 # Find spdlog
 # ============================================================
 function(find_spdlog_package)
-    message(STATUS "Fetching spdlog v1.16.0 via CPM")
+    message(STATUS "Searching for spdlog...")
+
+    # Attempt CONFIG (vcpkg, Conan)
+    find_package(spdlog CONFIG QUIET)
+
+    if(NOT spdlog_FOUND)
+        message(STATUS "spdlog not found via CONFIG, trying MODULE...")
+        # Attempt MODULE (Findspdlog.cmake)
+        find_package(spdlog MODULE QUIET)
+    endif()
     
-    CPMAddPackage(
-        NAME spdlog
-        GITHUB_REPOSITORY gabime/spdlog
-        GIT_TAG         v1.16.0
-        OPTIONS         "SPDLOG_HEADER_ONLY ON"
-    )
-
-    if(TARGET spdlog::spdlog_header_only OR TARGET spdlog::spdlog)
+    if(spdlog_FOUND)
         set(spdlog_FOUND TRUE PARENT_SCOPE)
-        set(spdlog_VERSION "1.16.0" PARENT_SCOPE)
+        set(spdlog_VERSION ${spdlog_VERSION} PARENT_SCOPE)
     else()
-        message(FATAL_ERROR "Failed to download spdlog via CPM.")
+        message(FATAL_ERROR "spdlog not found. Please install it via your package manager or vcpkg/conan.")
     endif()
 endfunction()
-
-# ============================================================
-# Find magic_enum
-# ============================================================
-function(find_magic_enum_package)
-    message(STATUS "Fetching magic_enum v0.9.7 via CPM")
-
-    CPMAddPackage(
-        NAME magic_enum
-        GITHUB_REPOSITORY Neargye/magic_enum
-        GIT_TAG         v0.9.7
-    )
-
-    if(TARGET magic_enum::magic_enum)
-        set(magic_enum_FOUND TRUE PARENT_SCOPE)
-        set(magic_enum_VERSION "0.9.7" PARENT_SCOPE)
-    else()
-        message(FATAL_ERROR "Failed to download magic_enum via CPM.")
-    endif()
-endfunction()
-
 
 # ============================================================
 # Find OpenImageIO
@@ -144,6 +123,27 @@ function(warn_halide_requirements)
     message(STATUS "╚════════════════════════════════════════════════════════════╝")
     message(STATUS "")
 endfunction()
+
+# ============================================================
+# Find magic_enum
+# ============================================================
+function(find_magic_enum_package)
+    message(STATUS "Fetching magic_enum v0.9.7 via CPM")
+
+    CPMAddPackage(
+        NAME magic_enum
+        GITHUB_REPOSITORY Neargye/magic_enum
+        GIT_TAG         v0.9.7
+    )
+
+    if(TARGET magic_enum::magic_enum)
+        set(magic_enum_FOUND TRUE PARENT_SCOPE)
+        set(magic_enum_VERSION "0.9.7" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Failed to download magic_enum via CPM.")
+    endif()
+endfunction()
+
 
 # ============================================================
 # Find Exiv2

--- a/cmake/PackageHelpers.cmake
+++ b/cmake/PackageHelpers.cmake
@@ -1,11 +1,31 @@
 # PackageHelpers.cmake - Helper functions to find and verify required packages
 
 # ============================================================
+# Download CPM.cmake automatically if not present
+# ============================================================
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
+    message(STATUS "Downloading CPM.cmake...")
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/cmake")
+    file(DOWNLOAD
+        https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/get_cpm.cmake
+        "${CMAKE_BINARY_DIR}/cmake/CPM.cmake"
+        TLS_VERIFY ON
+    )
+endif()
+
+include("${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
+message(STATUS "Using CPM.cmake from: ${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
+
+
+# ============================================================
 # Find all required packages
 # ============================================================
 function(find_required_packages)
-    # spdlog (mandatory)
+    # spdlog (mandatory) via CPM
     find_spdlog_package()
+
+    # magic_enum (mandatory) via CPM
+    find_magic_enum_package()
 
     # OpenImageIO (mandatory)
     find_openimageio_package()
@@ -16,11 +36,7 @@ function(find_required_packages)
     # Exiv2 (mandatory for serialization)
     find_exiv2_package()
 
-    # magic_enum (mandatory)
-    find_magic_enum_package()
-    
     # Qt6 will be searched by the sub-projects ui/desktop, ui/mobile
-
     summarize_found_packages()
     warn_halide_requirements()
 endfunction()
@@ -30,24 +46,43 @@ endfunction()
 # Find spdlog
 # ============================================================
 function(find_spdlog_package)
-    message(STATUS "Searching for spdlog...")
-
-    # Attempt CONFIG (vcpkg, Conan)
-    find_package(spdlog CONFIG QUIET)
-
-    if(NOT spdlog_FOUND)
-        message(STATUS "spdlog not found via CONFIG, trying MODULE...")
-        # Attempt MODULE (Findspdlog.cmake)
-        find_package(spdlog MODULE QUIET)
-    endif()
+    message(STATUS "Fetching spdlog v1.16.0 via CPM")
     
-    if(spdlog_FOUND)
+    CPMAddPackage(
+        NAME spdlog
+        GITHUB_REPOSITORY gabime/spdlog
+        GIT_TAG         v1.16.0
+        OPTIONS         "SPDLOG_HEADER_ONLY ON"
+    )
+
+    if(TARGET spdlog::spdlog_header_only OR TARGET spdlog::spdlog)
         set(spdlog_FOUND TRUE PARENT_SCOPE)
-        set(spdlog_VERSION ${spdlog_VERSION} PARENT_SCOPE)
+        set(spdlog_VERSION "1.16.0" PARENT_SCOPE)
     else()
-        message(FATAL_ERROR "spdlog not found. Please install it via your package manager or vcpkg/conan.")
+        message(FATAL_ERROR "Failed to download spdlog via CPM.")
     endif()
 endfunction()
+
+# ============================================================
+# Find magic_enum
+# ============================================================
+function(find_magic_enum_package)
+    message(STATUS "Fetching magic_enum v0.9.7 via CPM")
+
+    CPMAddPackage(
+        NAME magic_enum
+        GITHUB_REPOSITORY Neargye/magic_enum
+        GIT_TAG         v0.9.7
+    )
+
+    if(TARGET magic_enum::magic_enum)
+        set(magic_enum_FOUND TRUE PARENT_SCOPE)
+        set(magic_enum_VERSION "0.9.7" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Failed to download magic_enum via CPM.")
+    endif()
+endfunction()
+
 
 # ============================================================
 # Find OpenImageIO
@@ -106,52 +141,6 @@ function(warn_halide_requirements)
     message(STATUS "║  - Build time: 30-240 minutes (depending on hardware)      ║")
     message(STATUS "╚════════════════════════════════════════════════════════════╝")
     message(STATUS "")
-endfunction()
-
-# ============================================================
-# Find magic_enum
-# ============================================================
-function(find_magic_enum_package)
-    message(STATUS "Searching for magic_enum...")
-
-    # Attempt CONFIG first (expects magic_enum-config.cmake from vcpkg, Conan, etc.)
-    find_package(magic_enum CONFIG QUIET)
-
-    if(NOT magic_enum_FOUND)
-        message(STATUS "magic_enum not found via CONFIG, trying MODULE...")
-        # Attempt MODULE (expects Findmagic_enum.cmake or checks standard paths)
-        find_package(magic_enum MODULE QUIET)
-    endif()
-
-    # If still not found, or if magic_enum is header-only without CMake config, try manual search
-    if(NOT magic_enum_FOUND)
-        message(STATUS "magic_enum not found via CONFIG/MODULE. Attempting manual search for header-only...")
-        find_path(MAGIC_ENUM_INCLUDE_DIR
-            NAMES magic_enum/magic_enum.hpp # The main header file we are looking for
-            PATHS /usr/local/include       # Standard location after manual install (e.g., GitHub Actions step)
-                  /usr/include             # Standard system location (e.g., after apt install if headers were there)
-                  # Add other potential standard paths if needed
-        )
-
-        if(MAGIC_ENUM_INCLUDE_DIR)
-            # Create an INTERFACE imported target for header-only library
-            add_library(magic_enum::magic_enum INTERFACE IMPORTED)
-            target_include_directories(magic_enum::magic_enum INTERFACE ${MAGIC_ENUM_INCLUDE_DIR})
-            set(magic_enum_FOUND TRUE)
-            message(STATUS "magic_enum found manually: ${MAGIC_ENUM_INCLUDE_DIR}")
-        else()
-             message(FATAL_ERROR "magic_enum not found via CONFIG, MODULE, or manual search. Check installation.")
-        endif()
-    endif()
-
-    if(magic_enum_FOUND)
-        # Export the FOUND status to the parent scope
-        set(magic_enum_FOUND TRUE PARENT_SCOPE)
-        # No need to export the target name if using it explicitly in target_link_libraries
-        # The target magic_enum::magic_enum should be available now
-    else()
-        message(FATAL_ERROR "magic_enum not found. Please ensure it is installed (e.g., via vcpkg, apt install libmagicenum-dev, or manual install).")
-    endif()
 endfunction()
 
 # ============================================================

--- a/cmake/PackageHelpers.cmake
+++ b/cmake/PackageHelpers.cmake
@@ -16,6 +16,8 @@ endif()
 include("${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
 message(STATUS "Using CPM.cmake from: ${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
 
+# for fmt, we want to use the header-only version to avoid linking issues
+add_compile_definitions(FMT_HEADER_ONLY=1)
 
 # ============================================================
 # Find all required packages

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # ==============================================================================
 RUN apt-get update && apt-get install -y \
     git ninja-build python3 python3-pip python3-venv ccache \
-    libspdlog-dev libcurl4-openssl-dev libxkbcommon-dev libgl1-mesa-dev \
+    libcurl4-openssl-dev libxkbcommon-dev libgl1-mesa-dev \
     libbrotli-dev libexpat1-dev libgtest-dev libinih-dev libssh-dev \
     libxml2-utils libz-dev zlib1g-dev libjpeg-dev libfreetype-dev \
     libpng-dev libuhd-dev libraw-dev libopencv-core-dev libopencv-imgproc-dev \
@@ -31,15 +31,6 @@ RUN aqt install-qt linux desktop 6.10.2 --outputdir /opt/qt -m qtdeclarative -m 
 # ==============================================================================
 ENV CMAKE_PREFIX_PATH="/opt/qt/6.10.2/gcc_64;/opt/exiv2;/opt/oiio"
 ENV LD_LIBRARY_PATH="/opt/exiv2/lib:/opt/oiio/lib"
-
-# ==============================================================================
-# Install magic_enum
-# ==============================================================================
-RUN git clone https://github.com/Neargye/magic_enum.git /tmp/magic_enum && \
-    cd /tmp/magic_enum && git checkout v0.9.7 && \
-    mkdir -p /usr/local/include/magic_enum && \
-    cp include/magic_enum/*.hpp /usr/local/include/magic_enum/ && \
-    rm -rf /tmp/*
 
 # ==============================================================================
 # Build and install Exiv2

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # ==============================================================================
 RUN apt-get update && apt-get install -y \
     git ninja-build python3 python3-pip python3-venv ccache \
-    libcurl4-openssl-dev libxkbcommon-dev libgl1-mesa-dev \
+    libspdlog-dev libcurl4-openssl-dev libxkbcommon-dev libgl1-mesa-dev \
     libbrotli-dev libexpat1-dev libgtest-dev libinih-dev libssh-dev \
     libxml2-utils libz-dev zlib1g-dev libjpeg-dev libfreetype-dev \
     libpng-dev libuhd-dev libraw-dev libopencv-core-dev libopencv-imgproc-dev \

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,11 @@
       ]
     },
     {
+      "name": "spdlog",
+      "default-features": false,
+      "version>=": "1.16.0"
+    },
+    {
       "name": "exiv2",
       "default-features": false,
       "version>=": "0.28.7"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,19 +10,9 @@
       ]
     },
     {
-      "name": "spdlog",
-      "default-features": false,
-      "version>=": "1.16.0"
-    },
-    {
       "name": "exiv2",
       "default-features": false,
       "version>=": "0.28.7"
-    },
-    {
-      "name": "magic-enum",
-      "default-features": false,
-      "version>=": "0.9.7"
     }
   ],
     "features": {


### PR DESCRIPTION
This PR migrates two header-only dependencies (`spdlog`, `magic_enum`) from external package managers (vcpkg, Homebrew, APT) to **CPM.cmake** (CMake Package Manager). This simplifies dependency management, reduces platform-specific setup, and ensures consistent versions across all build environments.

## 🔑 Changes

### CMake Integration
- **`PackageHelpers.cmake`**: Added CPM-based fetching for `spdlog` and `magic_enum`
- **Header-only mode**: Added `add_compile_definitions(FMT_HEADER_ONLY=1)` to prevent linking issues with spdlog's fmt dependency
- **Version pinning**: Dependencies are fetched from specific Git tags for reproducibility

### Dependency Cleanup
| Platform | Before | After |
|----------|--------|-------|
| **vcpkg** | `spdlog`, `magic_enum` in manifest | Removed |
| **Homebrew (macOS)** | `brew install spdlog magic-enum` in CI | Removed |
| **APT (Ubuntu)** | `libspdlog-dev` in Dockerfile | Removed |
| **CPM** | — | ✅ `spdlog@1.16.0`, `magic_enum@0.9.7` |

### CI/CD Updates
- **`.github/workflows/macos_brew.yml`**: Removed brew installation steps for these libraries
- **`docker/debian/Dockerfile`**: Removed `libspdlog-dev` and manual `magic_enum` clone/install

## 🎯 Benefits

| Aspect | Improvement |
|--------|------------|
| **Simplicity** | Single CMake-based dependency resolution; no need to manage vcpkg/Homebrew/APT separately |
| **Consistency** | Same library versions across Windows, macOS, and Linux builds |
| **Build Time** | Header-only mode avoids compilation/linking of spdlog; faster incremental builds |
| **Portability** | New contributors can build without pre-installing system packages |
| **Maintenance** | Centralized dependency declarations in `PackageHelpers.cmake` |

## ⚠️ Migration Notes

1. **First build**: CPM will download dependencies from GitHub; ensure network access is available.
2. **Offline builds**: CPM supports offline mode via `CPM_USE_LOCAL_PACKAGES`; see [CPM documentation](https://github.com/cpm-cmake/CPM.cmake) for configuration.
3. **No API changes**: This is a build-system-only change; no code modifications required in application logic.


## 🔗 Related

- [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) – CMake dependency manager
- [spdlog](https://github.com/gabime/spdlog) – Fast C++ logging library (header-only mode)
- [magic_enum](https://github.com/Neargye/magic_enum) – Compile-time enum reflection (header-only)

---

*Branch*: `features/cpm`  
*Base*: `develop`  
*Author*: Yacine Benaffane