### PR TITLE
Features/local build : [Docs] Streamline Local Build Setup with Automation Scripts

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     libxml2-utils libz-dev zlib1g-dev libjpeg-dev libfreetype-dev \
     libpng-dev libuhd-dev libraw-dev libopencv-core-dev libopencv-imgproc-dev \
     libjxl-dev libheif-dev libpystring-dev libtiff-dev libimath-dev \
-    libopenexr-dev libopencolorio-dev \
+    libopenexr-dev \
     libyaml-cpp-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/building/BUILDING_LINUX.md
+++ b/docs/building/BUILDING_LINUX.md
@@ -16,25 +16,12 @@ This method uses an automated script that compiles Exiv2, OpenImageIO, and magic
 From the root of the project, run:
 
 ```bash
-./setup/setup_linux.sh
+chmod +x setup/setup-ubuntu.sh
+./setup/setup_ubuntu.sh
 ```
 (Note: You can look inside this script if you prefer to run the installation steps manually).
 
 If system packages are unavailable, too old, or if you need specific configurations not provided by your distribution. You need to adapt.
-
-### Qt Installation (Required for UI)
-
-The setup script does not install Qt. It is highly recommended to use the official Qt Online Installer for Linux.
-
-Alternatively, you can use the aqtinstall Python tool:
-
-```bash
-pip3 install aqtinstall
-aqt install-qt linux desktop 6.10.2 --outputdir /opt/qt -m qtdeclarative -m qtshadertools
-```
-
-If you install Qt manually, make sure to set the CMAKE_PREFIX_PATH environment variable to point to your Qt installation (e.g., /opt/qt/6.10.2/gcc_64 or the path chosen via the installer).
-
 
 ## 🚀Build the project
 * You can omit -DBUILD_DESKTOP_UI=ON if you don't want to compile the UI.

--- a/docs/building/BUILDING_LINUX.md
+++ b/docs/building/BUILDING_LINUX.md
@@ -17,7 +17,7 @@ From the root of the project, run:
 
 ```bash
 chmod +x setup/setup-ubuntu.sh
-./setup/setup_ubuntu.sh
+./setup/setup-ubuntu.sh
 ```
 (Note: You can look inside this script if you prefer to run the installation steps manually).
 

--- a/docs/building/BUILDING_LINUX.md
+++ b/docs/building/BUILDING_LINUX.md
@@ -1,157 +1,64 @@
 # 🐧 Linux Building Guide
-This guide covers building CaptureMoment on Linux. You can choose between using system packages (faster) or building dependencies from source (more control, potentially newer versions).
+This guide covers building CaptureMoment on Linux. The recommended method uses an automated script to build dependencies from source, ensuring you get the exact same versions and configuration as our CI pipeline.
 
-## 📦 Building with System Packages (Recommended)
+## 📦 Setting up Dependencies (Recommended) on Ubuntu/Debian
 
-This is the fastest method as it uses pre-compiled binaries via your distribution's package manager.
-
-### Ubuntu 25.04 / Debian Testing (or newer versions with required packages)
-
-Install the necessary build tools and dependencies using the package manager:
+### 1. Install core build tools
 
 ```bash
 sudo apt update
 sudo apt install -y build-essential cmake ninja-build
-
-# Logging
-sudo apt install -y libspdlog-dev
-
-# Image I/O and Processing
-sudo apt install -y libopenimageio-dev # Includes dependencies like libtiff-dev, libjpeg-dev, etc.
-
-# Metadata Handling
-sudo apt install -y libexiv2-dev # For XMP metadata
-sudo apt install -y libmagicenum-dev # For safe enum-to-string conversion
-
-# Potentially needed system libraries
-sudo apt install -y libcurl4-openssl-dev # For network features in Exiv2 (if enabled)
-sudo apt install -y libxkbcommon-dev     # For Qt Wayland support (if applicable)
 ```
 
-## 📦 Manual Build of Dependencies (Advanced/Custom)
+### 2. Run the automated setup script
+This method uses an automated script that compiles Exiv2, OpenImageIO, and magic_enum from source to guarantee version consistency.
 
-Use this method if system packages are unavailable, too old, or if you need specific configurations not provided by your distribution. This involves downloading, configuring, compiling, and installing libraries individually.
+From the root of the project, run:
 
-Make sure you have : ninja, cmake 
+```bash
+./setup/setup_linux.sh
+```
+(Note: You can look inside this script if you prefer to run the installation steps manually).
 
-### Install the libraries
-```powershell
-sudo apt install -y libspdlog-dev 
+If system packages are unavailable, too old, or if you need specific configurations not provided by your distribution. You need to adapt.
 
-# Maybe we need it
-sudo apt install -y libcurl4-openssl-dev
-sudo apt install -y libxkbcommon-dev
+### Qt Installation (Required for UI)
+
+The setup script does not install Qt. It is highly recommended to use the official Qt Online Installer for Linux.
+
+Alternatively, you can use the aqtinstall Python tool:
+
+```bash
+pip3 install aqtinstall
+aqt install-qt linux desktop 6.10.2 --outputdir /opt/qt -m qtdeclarative -m qtshadertools
 ```
 
-### Build OpenImageIO
-```powershell
-sudo apt install -y \
-libjpeg-dev \
-libfreetype-dev \
-libpng-dev \
-libuhd-dev \
-libraw-dev \
-libopencv-core-dev libopencv-imgproc-dev \
-libjxl-dev \
-libheif-dev \
-libpystring-dev \
-libtiff-dev \
-libimath-dev \
-libopenexr-dev \
-libopencolorio-dev \
-zlib1g-dev \
-libjpeg-turbo8-dev
-```
+If you install Qt manually, make sure to set the CMAKE_PREFIX_PATH environment variable to point to your Qt installation (e.g., /opt/qt/6.10.2/gcc_64 or the path chosen via the installer).
 
-Compilation :
-
-```powershell
- git clone https://github.com/AcademySoftwareFoundation/OpenImageIO.git /tmp/oiio-src
-cd /tmp/oiio-src
-git checkout v3.1.8.0
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
--DCMAKE_INSTALL_PREFIX=/opt/oiio \
--DOpenImageIO_BUILD_MISSING_DEPS=required \
--DSTOP_ON_WARNING=0 \
--DOIIO_BUILD_TOOLS=OFF \
--DOIIO_BUILD_TESTS=OFF \
--DUSE_PYTHON=OFF \
-..
-
-cmake --build . --parallel $(nproc)
-sudo cmake --install .
-```
-
-### magic-enum
-Magic enum is header-only, so copying the headers is sufficient.
-
-
-```powershell
-git clone https://github.com/Neargye/magic_enum.git /tmp/magic_enum
-cd /tmp/magic_enum
-git checkout v0.9.7
-sudo mkdir -p /usr/local/include/magic_enum
-sudo cp include/magic_enum/*.hpp /usr/local/include/magic_enum/
-```
-
-### Exiv2
-```powershell
-sudo apt install -y \
-         ccache \
-         libbrotli-dev \
-         libexpat1-dev \
-         libgtest-dev \
-         libinih-dev \
-         libssh-dev \
-         libxml2-utils \
-         libz-dev \
-         zlib1g-dev
-        shell: bash
-```
-
-Build :
-
-```powershell
-git clone https://github.com/Exiv2/exiv2.git /tmp/exiv2-src
-cd /tmp/exiv2-src
-git checkout v0.28.7
-    
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-        -DCMAKE_INSTALL_PREFIX=/opt/exiv2 \
-        -DBUILD_SHARED_LIBS=ON \
-        -DBUILD_WITH_CCACHE=ON \
-        ..
-    
-cmake --build . --parallel $(nproc)
-sudo cmake --install .
-    
-echo "CMAKE_PREFIX_PATH=/opt/exiv2:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
-```
 
 ## 🚀Build the project
-* You can remove desktio_ui if you don't want to compile the ui
-* You can also use debug-ninja-linux instead of release-ninja-linux
-```powershell
-# Use a generic preset that doesn't rely on specific paths (like *-homebrew presets)
-# Enable the desktop UI if desired
+* You can omit -DBUILD_DESKTOP_UI=ON if you don't want to compile the UI.
+* You can swap release-ninja for debug-ninja (or any other preset from the table below).
+
+```bash
+# Configure the project using a generic preset and enable the Desktop UI
 cmake --preset release-ninja -DBUILD_DESKTOP_UI=ON
 
 # Or, for a debug build:
 # cmake --preset debug-ninja -DBUILD_DESKTOP_UI=ON
 
-# Compile using all available cores
+# Compile using all available CPU cores
 cmake --build build/release-ninja -j$(nproc) # Adjust path if using debug preset
 ```
 
-**Build Commands**
+### Alternative Build Commands
 
-Since dependencies are installed system-wide, we use generic presets. Don't forget to enable the UI if you wanna to build it!
+Since dependencies are installed system-wide (in /opt/ or /usr/local/), we use generic presets.
 
-```powershell
+```bash
 # Configure in Debug and enable the UI
 cmake --preset debug -Ddesktop_ui=ON
+
 # Compile using all available cores
 cmake --build build/debug -j$(nproc)
 ```

--- a/docs/building/BUILDING_MACOS.md
+++ b/docs/building/BUILDING_MACOS.md
@@ -1,20 +1,24 @@
 # macOS Building Guide
-For macOS, we recommend using Homebrew to manage dependencies (OpenImageIO, Halide, Exiv2, magic_enum).
+This guide covers building CaptureMoment on macOS. The recommended method uses an automated script to build core dependencies from source, ensuring you get the exact same versions and configuration as our Linux and CI pipelines, avoiding unpredictable Homebrew updates.
 
-## Prerequisites
-* Homebrew
+##  Setting up Dependencies (Recommended)
 
-## 📦Installing Dependencies
+You need Homebrew and a few base build tools:
 
-make sure you have cmake, ninja installed
-
-```powershell
+```bash
 brew update
-brew install openimageio
-brew install spdlog
-brew install exiv2
-brew install magic_enum
+brew install cmake ninja ccache
 ```
+
+## 2. Run the automated setup script
+This method uses an automated script that compiles Exiv2, OpenImageIO, and magic_enum from source to guarantee strict version consistency. (Note: The script uses Homebrew in the background to fetch the underlying base libraries required for the build).
+
+From the root of the project, run:
+
+```bash
+./setup/setup-macos.sh
+```
+(Note: You can look inside this script if you prefer to run the installation steps manually).
 
 ## 🚀 Build Instructions
 We use custom Homebrew presets that configure the necessary paths (CMAKE_PREFIX_PATH). Don't forget to enable the UI if you want!

--- a/docs/building/BUILDING_MAIN.md
+++ b/docs/building/BUILDING_MAIN.md
@@ -14,8 +14,8 @@ Before selecting your platform, ensure you have these tools:
 
 1.  **CMake 4.2+**
 2.  **C++23 Compiler**:
-    * **Windows**: MSVC 2026 or MinGW (GCC 13+).
-    * **Linux**: GCC 13+ or Clang 16+.
+    * **Windows**: MSVC 2026 or MinGW (GCC 16+).
+    * **Linux**: GCC 16+
     * **macOS**: Apple Clang 16+ (Xcode 15+).
 
 ---
@@ -34,24 +34,22 @@ Before selecting your platform, ensure you have these tools:
 | Library     | Version      | Link                                                     |
 |-------------|:------------------:|----------------------------------------------------------|
 | OpenImageIO | 3.1.8.0             | https://github.com/AcademySoftwareFoundation/OpenImageIO |
-| Halide      | 18.x +           | https://github.com/halide/Halide                         |
+| Halide      | 21.0           | https://github.com/halide/Halide                         |
 | spdlog      | 1.16.0      | https://github.com/gabime/spdlog                         |
 | Exiv2         | 0.28.7| https://github.com/Exiv2/exiv2  
-| Magicmagic_enum          |0.9.7| https://github.com/Neargye/magic_enum/
-|  Qt6           | 6.10| https://doc.qt.io/qt-6/ 
+| Magic Enum         |0.9.7| https://github.com/Neargye/magic_enum/
+|  Qt6           | 6.10.x| https://doc.qt.io/qt-6/
 
 ---
 ## 📦 How to build
 
-### Build Halide
-First of all you need to build Halide
-* [**HALIDE**](./BUILDING_HALIDE.md).
+### 1. Build Halide
+[➡️ Read the guide for Halide](INSTALLATION_HALIDE.md).
 
-### Qt-UI (not mandatory)
-If you want to use UI, you need to use Qt.
-You can download directly from the official website (better). Or just install the packages. Choose the **6.10.x** version
+### 2. Setup Qt (Optional - Required for UI only)
+If you want to build the Desktop UI. Please follow the dedicated guide to install `Qt` on your machine:  [➡️ Read the Building Qt Guide](INSTALLATION_QT.md).
 
-### 🌍 Choose Your Platform
+### 3. Setup Dependencies & Compile
 Click the link for your OS for detailed instructions:
 
 * [🟦 **Windows**](./guidelines/BUILDING_WINDOWS.md).

--- a/docs/building/BUILDING_WINDOWS.md
+++ b/docs/building/BUILDING_WINDOWS.md
@@ -16,8 +16,6 @@ cd C:\vcpkg
 ### 2. Enable Binary Caching (Crucial!)
 To avoid recompiling LLVM every time you clean your project, enable local binary caching. Check if it's ON by default.
 
-
-
 ```PowerShell
 # Create a permanent cache folder
 mkdir C:\vcpkg_cache
@@ -76,7 +74,7 @@ cmake --build build/release-vcpkg-mingw
 Don't forget to use -DHALIDE_DIR=/path/to/halide(cmake) of your IDE build to add the path of Halide
 
 #### Qt Creator
-Open the root CMakeLists.txt with Qt Creator and choose the build vcpkg core msvc or mingw (with no desktop). And when you are in the pannel of the configuration, activate BUILD_UIBUILD_DESKTOP_UI to ON
+Open the root CMakeLists.txt with Qt Creator and choose the build vcpkg core msvc or mingw (with no desktop). And when you are in the pannel of the configuration, activate BUILD_DESKTOP_UI to ON
 
 #### Visual Studio
 Not configured at yet

--- a/docs/building/INSTALLATION_HALIDE.md
+++ b/docs/building/INSTALLATION_HALIDE.md
@@ -1,11 +1,9 @@
-# 🏗️ Building Halide with Full GPU Support
+# 🏗️ Halide Installation
 
-## Overview
-
-This guide provides clear instructions for obtaining Halide 18.0.0 or newer with support for various GPU backends (CUDA, OpenCL, Vulkan, DirectX12) as well as CPU-only configurations.
+This guide provides clear instructions for obtaining Halide with support for various GPU backends (CUDA, OpenCL, Vulkan, DirectX12) as well as CPU-only configurations.
 
 ⚠️ **Important**: The official pre-built binaries do not include GPU support by default. To use GPU acceleration, you must either:
-- Use a package manager that explicitly enables GPU features, or
+- Use a package manager that explicitly enables GPU features
 - Build Halide from source with the appropriate flags (see official documentation).
 
 ⚠️ Important: Disk Space & Build Time
@@ -15,14 +13,7 @@ Compiling dependencies (especially LLVM via Halide) is resource-intensive.
 * **Optimized Build** (Release only): Requires ~40 GB. ~40% faster.
 ---
 
-## System Requirements
-
-## Version Requirement
-
-- **Minimum Version**: Halide 18.0 +
-- Older versions lack critical GPU scheduling improvements and may not support modern hardware features.
-
-### GPU Backend Requirements
+## GPU Backend Requirements
 
 | Backend | Platform | Requirements |
 |---------|----------|--------------|
@@ -32,25 +23,23 @@ Compiling dependencies (especially LLVM via Halide) is resource-intensive.
 | DirectX12 | Windows only | Windows 10/11, compatible GPU |
 
 
-## Installation Method From Release repos quickly (ONLY CPU)
-* Download a release from here : https://github.com/halide/Halide/releases
+## Automatic installation Method With ONLY CPU
 
-* And when you want to build the projet Capture Moment. You can just set the path by adding this argument.
+### Installation Method With PIP
 
 ```bash
--DHALIDE_DIR="pathtohalide/lib/cmake/Halide"
-# Path to the cmake Halide
+pip3 install halide
 ```
 
-## Installation Methods From Dependecies Managers
+### Installation Methods From Dependecies Managers
 
-### Ubuntu / Debian (APT)
+#### Ubuntu / Debian (APT)
 
 **More details:** https://launchpad.net/ubuntu/+source/halide/
 
 ❌ **Note**: APT packages do not include GPU support.
 
-### macOS (Homebrew)
+#### macOS (Homebrew)
 
 ```bash
 brew install halide
@@ -59,11 +48,31 @@ brew install halide
 
 ❌ **Note**: Maybe packages do not include GPU support.
 
-### Windows (vcpkg)
+#### Windows (vcpkg)
+
+```bash
+vcpkg install halide:x64-windows
+```
 
 **More details:** https://vcpkg.link/ports/halide
 
 You can also install GPU support as Feature Dependencies
+
+
+
+## Manual installation 
+
+### From Release repos (ONLY CPY)
+* Download a release from here : https://github.com/halide/Halide/releases
+
+#### Add to the project
+* When you want to build the projet Capture Moment. You can just set the path by adding this argument when you start building at the final with cmake.
+
+```bash
+-DHALIDE_DIR="pathtohalide/lib/cmake/Halide"
+# Path to the cmake Halide
+```
+
 
 ## Source Code & Official Build Documentation
 

--- a/docs/building/INSTALLATION_HALIDE.md
+++ b/docs/building/INSTALLATION_HALIDE.md
@@ -1,19 +1,9 @@
 # 🏗️ Halide Installation
-
 This guide provides clear instructions for obtaining Halide with support for various GPU backends (CUDA, OpenCL, Vulkan, DirectX12) as well as CPU-only configurations.
 
-⚠️ **Important**: The official pre-built binaries do not include GPU support by default. To use GPU acceleration, you must either:
-- Use a package manager that explicitly enables GPU features
-- Build Halide from source with the appropriate flags (see official documentation).
-
-⚠️ Important: Disk Space & Build Time
-
-Compiling dependencies (especially LLVM via Halide) is resource-intensive.
-* **Standard Build** (Debug + Release): Requires ~80-100 GB. Can take 2h+.
-* **Optimized Build** (Release only): Requires ~40 GB. ~40% faster.
 ---
 
-## GPU Backend Requirements
+# GPU Backend supported
 
 | Backend | Platform | Requirements |
 |---------|----------|--------------|
@@ -22,21 +12,48 @@ Compiling dependencies (especially LLVM via Halide) is resource-intensive.
 | Vulkan | Cross-platform | Vulkan SDK and compatible driver |
 | DirectX12 | Windows only | Windows 10/11, compatible GPU |
 
+## How to Configure Halide
 
-## Automatic installation Method With ONLY CPU
+### 🥇 Method 1 : Pre-built Binary (Recommended & Fastest)
+This is the easiest way to get a fully working Halide (with CPU + GPU support) in seconds without compiling LLVM.
 
-### Installation Method With PIP
-
+#### Via PIP
 ```bash
 pip3 install halide
 ```
 
-### Installation Methods From Dependecies Managers
+##### ⚠️ Important (Runtime Dependency)
+After compiling, you must manually copy the Halide binary file (.dll, .so, or .dylib) from your Python site-packages directory into your final build folder so the executable can find it.
+
+#### Via the official repos
+[➡️ Download pre-build binary here](https://github.com/halide/Halide/releases)
+
+When you compile the project with cmake, add this argument
+
+```bash
+-DHALIDE_DIR="path/to/halide/lib/cmake/Halide"
+# Path to the cmake Halide
+```
+
+##### ⚠️ Important (Runtime Dependency):
+CMake will successfully link the library during compilation, but your operating system needs help locating it at runtime. Once the build is complete, you must manually copy the shared library file (e.g., Halide.dll on Windows, .so on Linux, or .dylib on macOS) directly into your final build output directory, next to your executable.
+
+* **Example on Windows**
+
+```bash
+cmake --preset release-vcpkg-msvc -DHALIDE_DIR="C:/project/halide/lib/cmake/Halide"
+```
+
+### 🥈 Method 2: Package Managers (CPU Only)
 
 #### Ubuntu / Debian (APT)
 
-**More details:** https://launchpad.net/ubuntu/+source/halide/
+```bash
+sudo apt install libhalide-dev
+```
 
+[➡️ See here if the name package is invalid](https://launchpad.net/ubuntu/+source/halide/)
+ 
 ❌ **Note**: APT packages do not include GPU support.
 
 #### macOS (Homebrew)
@@ -44,7 +61,7 @@ pip3 install halide
 ```bash
 brew install halide
 ```
-**More details:** https://formulae.brew.sh/formula/halide
+[➡️ More details](https://formulae.brew.sh/formula/halide)
 
 ❌ **Note**: Maybe packages do not include GPU support.
 
@@ -54,29 +71,28 @@ brew install halide
 vcpkg install halide:x64-windows
 ```
 
-**More details:** https://vcpkg.link/ports/halide
+[➡️ More details](https://vcpkg.link/ports/halide)
 
 You can also install GPU support as Feature Dependencies
 
 
+### 🥉 Method 3: Build from Source (For Advanced Users / Full GPU Control)
 
-## Manual installation 
+🔧 **Building from source is the only reliable way to enable full GPU support**. Users requiring GPU acceleration should follow the official CMake build documentation to compile Halide with the desired backends enabled.
 
-### From Release repos (ONLY CPY)
-* Download a release from here : https://github.com/halide/Halide/releases
+- **GitHub Repository**: https://github.com/halide/Halide
+- **Official Build Guide**: https://halide-lang.org/docs/md_doc_2_building_halide_with_c_make.html
+
+⚠️ Important: Disk Space & Build Time
+
+Compiling dependencies (especially LLVM via Halide) is resource-intensive.
+* **Standard Build** (Debug + Release): Requires ~80-100 GB. Can take 2h+.
+* **Optimized Build** (Release only): Requires ~40 GB. ~40% faster.
 
 #### Add to the project
 * When you want to build the projet Capture Moment. You can just set the path by adding this argument when you start building at the final with cmake.
 
 ```bash
--DHALIDE_DIR="pathtohalide/lib/cmake/Halide"
+-DHALIDE_DIR="path/to/halide/lib/cmake/Halide"
 # Path to the cmake Halide
 ```
-
-
-## Source Code & Official Build Documentation
-
-- **GitHub Repository**: https://github.com/halide/Halide
-- **Official Build Guide**: https://halide-lang.org/docs/md_doc_2_building_halide_with_c_make.html
-
-🔧 **Building from source is the only reliable way to enable full GPU support** (especially CUDA). Users requiring GPU acceleration should follow the official CMake build documentation to compile Halide with the desired backends enabled.

--- a/docs/building/INSTALLATION_QT.md
+++ b/docs/building/INSTALLATION_QT.md
@@ -1,0 +1,73 @@
+# ⚙️ Building Qt Guide
+CaptureMoment requires Qt 6.10.2 with the qtdeclarative and qtshadertools modules. You can install it using the official graphical installer or via the command-line tool aqtinstall.
+
+## List of modules for CaptureMoment
+* Core
+* Quick
+* Gui
+* GuiPrivate
+* ShaderTools
+
+## Method 1: Qt Maintenance Tool (Official Installer)
+
+This is the easiest method if you are setting up a development environment on your own machine.
+
+* [➡️ Go to the Official Qt Download page](BUILDING_HALIDE.md).
+* Download the Qt Online Installer for your operating system.
+
+## Method 2: aqtinstall (Command Line)
+This method is recommended for CI/CD pipelines or if you prefer a fast, scriptable installation without needing a Qt account.
+
+### Prerequisites
+You need Python and pip installed on your system.
+
+```bash
+pip3 install aqtinstall
+```
+
+#### Installation Commands
+##### On Linux (Ubuntu/Debian):
+
+```bash
+aqt install-qt linux desktop 6.10.2 --outputdir /opt/qt -m qtdeclarative -m qtshadertools
+```
+
+##### On macOS:
+
+```bash
+aqt install-qt mac desktop 6.10.2 --outputdir /opt/qt -m qtdeclarative -m qtshadertools
+```
+
+##### On Windows (PowerShell):
+
+```bash
+aqt install-qt windows desktop 6.10.2 --outputdir C:\Qt -m qtdeclarative -m qtshadertools
+```
+
+### Environment Configuration
+
+if `CMAKE_PREFIX_PATH` don't know the Qt path. You need to set the follow methods: 
+
+#### On Linux
+Add this to your `~/.bashrc` (adjust the path if you used the Maintenance Tool):
+
+
+```bash
+export CMAKE_PREFIX_PATH="/opt/qt/6.10.2/gcc_64:${CMAKE_PREFIX_PATH}"
+```
+
+#### On macOS
+Add this to your `~/.zshrc` (adjust the path if you used the Maintenance Tool, e.g., ~/Qt/6.10.2/macos):
+
+
+```bash
+export CMAKE_PREFIX_PATH="/opt/qt/6.10.2/macos:${CMAKE_PREFIX_PATH}"
+```
+
+#### On Windows
+Add this to your System Environment Variables via the Windows Search bar ("Edit the system environment variables" -> Environment Variables -> User variables):
+
+* **Variable name:** `CMAKE_PREFIX_PATH`
+* **Variable value:** `C:\Qt\6.10.2\msvc2022_64` (Adjust `msvc2022_64` based on your Visual Studio version, e.g., `mingw_64` if you use MinGW).
+* 
+Restart your computer after setting these variables!

--- a/setup/setup-macos.sh
+++ b/setup/setup-macos.sh
@@ -6,7 +6,6 @@
 # This script compiles dependencies from source to guarantee strict version
 # control, matching the exact versions used in the CI and Linux builds.
 # 
-# NOTE: Qt is NOT installed by this script. Use the official Qt Installer.
 # ==============================================================================
 
 set -e # Exit immediately if a command exits with a non-zero status
@@ -38,7 +37,7 @@ brew install \
 # Build and install Exiv2
 # ==============================================================================
 echo "[4/5] Building and installing Exiv2 v0.28.7..."
-if [ ! -d "/opt/exiv2" ]; then
+if [[ ! -d "/opt/exiv2" ]]; then
     git clone https://github.com/Exiv2/exiv2.git /tmp/exiv2-src
     cd /tmp/exiv2-src && git checkout v0.28.7
     
@@ -63,7 +62,7 @@ fi
 # Build and install OpenImageIO
 # ==============================================================================
 echo "[5/5] Building and installing OpenImageIO v3.1.8.0..."
-if [ ! -d "/opt/oiio" ]; then
+if [[ ! -d "/opt/oiio" ]]; then
     git clone https://github.com/AcademySoftwareFoundation/OpenImageIO.git /tmp/oiio-src
     cd /tmp/oiio-src && git checkout v3.1.8.0
     

--- a/setup/setup-macos.sh
+++ b/setup/setup-macos.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# ==============================================================================
+# CaptureMoment - macOS Local Setup Script
+# 
+# This script compiles dependencies from source to guarantee strict version
+# control, matching the exact versions used in the CI and Linux builds.
+# 
+# NOTE: Qt is NOT installed by this script. Use the official Qt Installer.
+# ==============================================================================
+
+set -e # Exit immediately if a command exits with a non-zero status
+
+echo "=============================================================================="
+echo "WARNING: This script does NOT install Qt."
+echo "Please make sure you have installed Qt manually and set your CMAKE_PREFIX_PATH"
+echo "environment variable accordingly before building the project."
+echo "=============================================================================="
+echo ""
+
+# ==============================================================================
+# System dependencies (via Homebrew)
+# ==============================================================================
+echo "[1/5] Installing base build tools via Homebrew..."
+brew update
+brew install cmake ninja ccache
+
+# Install the underlying libraries required to compile Exiv2 and OpenImageIO.
+# Homebrew handles these well, and we don't need strict version control on them.
+echo "[2/5] Installing underlying system libraries via Homebrew..."
+brew install \
+    spdlog libcurl xkbcommon \
+    brotli expat googletest inih libssh xmlstarlet zlib jpeg freetype png \
+    libuhd libraw opencv jxl libheif pystring tiff imath openexr \
+    yaml-cpp halide
+
+# ==============================================================================
+# Install magic_enum
+# ==============================================================================
+echo "[3/5] Installing magic_enum v0.9.7..."
+if [ ! -d "/usr/local/include/magic_enum" ]; then
+    git clone https://github.com/Neargye/magic_enum.git /tmp/magic_enum
+    cd /tmp/magic_enum && git checkout v0.9.7
+    sudo mkdir -p /usr/local/include/magic_enum
+    sudo cp include/magic_enum/*.hpp /usr/local/include/magic_enum/
+    rm -rf /tmp/magic_enum
+    echo "      -> magic_enum installed successfully."
+else
+    echo "      -> magic_enum already found, skipping."
+fi
+
+# ==============================================================================
+# Build and install Exiv2
+# ==============================================================================
+echo "[4/5] Building and installing Exiv2 v0.28.7..."
+if [ ! -d "/opt/exiv2" ]; then
+    git clone https://github.com/Exiv2/exiv2.git /tmp/exiv2-src
+    cd /tmp/exiv2-src && git checkout v0.28.7
+    
+    # On macOS, we need to tell CMake where Homebrew libraries are if they are keg-only
+    BREW_PREFIX=$(brew --prefix)
+    
+    cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/opt/exiv2 \
+          -DCMAKE_PREFIX_PATH="${BREW_PREFIX}" \
+          -DBUILD_SHARED_LIBS=ON
+    
+    cmake --build build --parallel $(sysctl -n hw.ncpu)
+    sudo cmake --install build
+    rm -rf /tmp/exiv2-src
+    echo "      -> Exiv2 installed successfully in /opt/exiv2."
+else
+    echo "      -> Exiv2 already found in /opt/exiv2, skipping."
+fi
+
+# ==============================================================================
+# Build and install OpenImageIO
+# ==============================================================================
+echo "[5/5] Building and installing OpenImageIO v3.1.8.0..."
+if [ ! -d "/opt/oiio" ]; then
+    git clone https://github.com/AcademySoftwareFoundation/OpenImageIO.git /tmp/oiio-src
+    cd /tmp/oiio-src && git checkout v3.1.8.0
+    
+    BREW_PREFIX=$(brew --prefix)
+    
+    mkdir build && cd build
+    cmake -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=/opt/oiio \
+           -DCMAKE_PREFIX_PATH="/opt/exiv2;${BREW_PREFIX}" \
+           -DOpenImageIO_BUILD_MISSING_DEPS=required \
+           -DSTOP_ON_WARNING=0 \
+           -DOIIO_BUILD_TOOLS=OFF \
+           -DOIIO_BUILD_TESTS=OFF \
+           -DUSE_PYTHON=OFF \
+           ..
+           
+    cmake --build . --parallel $(sysctl -n hw.ncpu)
+    sudo cmake --install .
+    rm -rf /tmp/oiio-src
+    echo "      -> OpenImageIO installed successfully in /opt/oiio."
+else
+    echo "      -> OpenImageIO already found in /opt/oiio, skipping."
+fi
+
+# ==============================================================================
+# Configuration for CMake and library paths
+# ==============================================================================
+echo ""
+echo "=============================================================================="
+echo "Configuring environment variables..."
+export CMAKE_PREFIX_PATH="/opt/exiv2:/opt/oiio:${CMAKE_PREFIX_PATH}"
+export DYLD_LIBRARY_PATH="/opt/exiv2/lib:/opt/oiio/lib:${DYLD_LIBRARY_PATH}" # DYLD instead of LD on macOS
+
+echo "To make these variables persistent, add the following lines to your ~/.zshrc:"
+echo "  export CMAKE_PREFIX_PATH=\"/opt/exiv2:/opt/oiio:\${CMAKE_PREFIX_PATH}\""
+echo "  export DYLD_LIBRARY_PATH=\"/opt/exiv2/lib:/opt/oiio/lib:\${DYLD_LIBRARY_PATH}\""
+echo "=============================================================================="
+echo ""
+echo "✅ Setup completed successfully! You can now build CaptureMoment."

--- a/setup/setup-macos.sh
+++ b/setup/setup-macos.sh
@@ -35,21 +35,6 @@ brew install \
     yaml-cpp halide
 
 # ==============================================================================
-# Install magic_enum
-# ==============================================================================
-echo "[3/5] Installing magic_enum v0.9.7..."
-if [ ! -d "/usr/local/include/magic_enum" ]; then
-    git clone https://github.com/Neargye/magic_enum.git /tmp/magic_enum
-    cd /tmp/magic_enum && git checkout v0.9.7
-    sudo mkdir -p /usr/local/include/magic_enum
-    sudo cp include/magic_enum/*.hpp /usr/local/include/magic_enum/
-    rm -rf /tmp/magic_enum
-    echo "      -> magic_enum installed successfully."
-else
-    echo "      -> magic_enum already found, skipping."
-fi
-
-# ==============================================================================
 # Build and install Exiv2
 # ==============================================================================
 echo "[4/5] Building and installing Exiv2 v0.28.7..."

--- a/setup/setup-ubuntu.sh
+++ b/setup/setup-ubuntu.sh
@@ -4,10 +4,7 @@
 # CaptureMoment - Linux Local Setup Script
 # 
 # This script automates the setup of the build environment and compiles the
-# required core dependencies (Exiv2, OpenImageIO, magic_enum) from source.
-# 
-# NOTE: Qt is NOT installed by this script. You must install Qt manually
-# and ensure CMAKE_PREFIX_PATH points to your Qt installation before building.
+# required core dependencies (Exiv2, OpenImageIO) from source.
 # ==============================================================================
 
 set -e # Exit immediately if a command exits with a non-zero status
@@ -43,7 +40,7 @@ pip3 install --break-system-packages cmake
 # Build and install Exiv2
 # ==============================================================================
 echo "[4/5] Building and installing Exiv2 v0.28.7..."
-if [ ! -d "/opt/exiv2" ]; then
+if [[ ! -d "/opt/exiv2" ]]; then
     git clone https://github.com/Exiv2/exiv2.git /tmp/exiv2-src
     cd /tmp/exiv2-src && git checkout v0.28.7
     
@@ -64,7 +61,7 @@ fi
 # Build and install OpenImageIO
 # ==============================================================================
 echo "[5/5] Building and installing OpenImageIO v3.1.8.0..."
-if [ ! -d "/opt/oiio" ]; then
+if [[ ! -d "/opt/oiio" ]]; then
     git clone https://github.com/AcademySoftwareFoundation/OpenImageIO.git /tmp/oiio-src
     cd /tmp/oiio-src && git checkout v3.1.8.0
     

--- a/setup/setup-ubuntu.sh
+++ b/setup/setup-ubuntu.sh
@@ -40,21 +40,6 @@ echo "[2/5] Installing Python core packages..."
 pip3 install --break-system-packages cmake
 
 # ==============================================================================
-# Install magic_enum (Header-only)
-# ==============================================================================
-echo "[3/5] Installing magic_enum..."
-if [ ! -d "/usr/local/include/magic_enum" ]; then
-    git clone https://github.com/Neargye/magic_enum.git /tmp/magic_enum
-    cd /tmp/magic_enum && git checkout v0.9.7
-    sudo mkdir -p /usr/local/include/magic_enum
-    sudo cp include/magic_enum/*.hpp /usr/local/include/magic_enum/
-    rm -rf /tmp/magic_enum
-    echo "      -> magic_enum installed successfully."
-else
-    echo "      -> magic_enum already found in /usr/local/include/magic_enum, skipping."
-fi
-
-# ==============================================================================
 # Build and install Exiv2
 # ==============================================================================
 echo "[4/5] Building and installing Exiv2 v0.28.7..."

--- a/setup/setup-ubuntu.sh
+++ b/setup/setup-ubuntu.sh
@@ -37,7 +37,7 @@ sudo apt-get update && sudo apt-get install -y \
 # Install Python core packages
 # ==============================================================================
 echo "[2/5] Installing Python core packages..."
-pip3 install --break-system-packages cmake halide
+pip3 install --break-system-packages cmake
 
 # ==============================================================================
 # Install magic_enum (Header-only)

--- a/setup/setup-ubuntu.sh
+++ b/setup/setup-ubuntu.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# ==============================================================================
+# CaptureMoment - Linux Local Setup Script
+# 
+# This script automates the setup of the build environment and compiles the
+# required core dependencies (Exiv2, OpenImageIO, magic_enum) from source.
+# 
+# NOTE: Qt is NOT installed by this script. You must install Qt manually
+# and ensure CMAKE_PREFIX_PATH points to your Qt installation before building.
+# ==============================================================================
+
+set -e # Exit immediately if a command exits with a non-zero status
+
+echo "=============================================================================="
+echo "WARNING: This script does NOT install Qt."
+echo "Please make sure you have installed Qt manually and set your CMAKE_PREFIX_PATH"
+echo "environment variable accordingly before building the project."
+echo "=============================================================================="
+echo ""
+
+# ==============================================================================
+# System dependencies
+# ==============================================================================
+echo "[1/5] Installing system dependencies..."
+sudo apt-get update && sudo apt-get install -y \
+    git ninja-build python3 python3-pip python3-venv ccache \
+    libspdlog-dev libcurl4-openssl-dev libxkbcommon-dev libgl1-mesa-dev \
+    libbrotli-dev libexpat1-dev libgtest-dev libinih-dev libssh-dev \
+    libxml2-utils libz-dev zlib1g-dev libjpeg-dev libfreetype-dev \
+    libpng-dev libuhd-dev libraw-dev libopencv-core-dev libopencv-imgproc-dev \
+    libjxl-dev libheif-dev libpystring-dev libtiff-dev libimath-dev \
+    libopenexr-dev libopencolorio-dev \
+    libyaml-cpp-dev
+
+# ==============================================================================
+# Install Python core packages
+# ==============================================================================
+echo "[2/5] Installing Python core packages..."
+pip3 install --break-system-packages cmake halide
+
+# ==============================================================================
+# Install magic_enum (Header-only)
+# ==============================================================================
+echo "[3/5] Installing magic_enum..."
+if [ ! -d "/usr/local/include/magic_enum" ]; then
+    git clone https://github.com/Neargye/magic_enum.git /tmp/magic_enum
+    cd /tmp/magic_enum && git checkout v0.9.7
+    sudo mkdir -p /usr/local/include/magic_enum
+    sudo cp include/magic_enum/*.hpp /usr/local/include/magic_enum/
+    rm -rf /tmp/magic_enum
+    echo "      -> magic_enum installed successfully."
+else
+    echo "      -> magic_enum already found in /usr/local/include/magic_enum, skipping."
+fi
+
+# ==============================================================================
+# Build and install Exiv2
+# ==============================================================================
+echo "[4/5] Building and installing Exiv2 v0.28.7..."
+if [ ! -d "/opt/exiv2" ]; then
+    git clone https://github.com/Exiv2/exiv2.git /tmp/exiv2-src
+    cd /tmp/exiv2-src && git checkout v0.28.7
+    
+    cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/opt/exiv2 \
+          -DBUILD_SHARED_LIBS=ON
+    
+    cmake --build build --parallel $(nproc)
+    sudo cmake --install build
+    rm -rf /tmp/exiv2-src
+    echo "      -> Exiv2 installed successfully in /opt/exiv2."
+else
+    echo "      -> Exiv2 already found in /opt/exiv2, skipping."
+fi
+
+# ==============================================================================
+# Build and install OpenImageIO
+# ==============================================================================
+echo "[5/5] Building and installing OpenImageIO v3.1.8.0..."
+if [ ! -d "/opt/oiio" ]; then
+    git clone https://github.com/AcademySoftwareFoundation/OpenImageIO.git /tmp/oiio-src
+    cd /tmp/oiio-src && git checkout v3.1.8.0
+    
+    mkdir build && cd build
+    cmake -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=/opt/oiio \
+           -DOpenImageIO_BUILD_MISSING_DEPS=required \
+           -DSTOP_ON_WARNING=0 \
+           -DOIIO_BUILD_TOOLS=OFF \
+           -DOIIO_BUILD_TESTS=OFF \
+           -DUSE_PYTHON=OFF \
+           ..
+           
+    cmake --build . --parallel $(nproc)
+    sudo cmake --install .
+    rm -rf /tmp/oiio-src
+    echo "      -> OpenImageIO installed successfully in /opt/oiio."
+else
+    echo "      -> OpenImageIO already found in /opt/oiio, skipping."
+fi
+
+# ==============================================================================
+# Configuration for CMake and library paths
+# ==============================================================================
+echo ""
+echo "=============================================================================="
+echo "Configuring environment variables..."
+export CMAKE_PREFIX_PATH="/opt/exiv2:/opt/oiio:${CMAKE_PREFIX_PATH}"
+export LD_LIBRARY_PATH="/opt/exiv2/lib:/opt/oiio/lib:${LD_LIBRARY_PATH}"
+
+echo "To make these variables persistent, add the following lines to your ~/.bashrc:"
+echo "  export CMAKE_PREFIX_PATH=\"/opt/exiv2:/opt/oiio:\${CMAKE_PREFIX_PATH}\""
+echo "  export LD_LIBRARY_PATH=\"/opt/exiv2/lib:/opt/oiio/lib:\${LD_LIBRARY_PATH}\""
+echo "=============================================================================="
+echo ""
+echo "✅ Setup completed successfully! You can now build CaptureMoment."

--- a/setup/setup-ubuntu.sh
+++ b/setup/setup-ubuntu.sh
@@ -30,7 +30,7 @@ sudo apt-get update && sudo apt-get install -y \
     libxml2-utils libz-dev zlib1g-dev libjpeg-dev libfreetype-dev \
     libpng-dev libuhd-dev libraw-dev libopencv-core-dev libopencv-imgproc-dev \
     libjxl-dev libheif-dev libpystring-dev libtiff-dev libimath-dev \
-    libopenexr-dev libopencolorio-dev \
+    libopenexr-dev \
     libyaml-cpp-dev
 
 # ==============================================================================


### PR DESCRIPTION
# 📋 Summary

This PR simplifies the local development setup process by introducing automated installation scripts for Ubuntu/Debian and macOS, alongside comprehensive documentation updates. The goal is to reduce manual configuration steps, ensure consistent dependency versions, and provide a "one-command" setup experience for new contributors.

## 🔑 Key Changes

### 📜 New Automation Scripts
| Script | Platform | Purpose |
|--------|----------|---------|
| `setup/setup-ubuntu.sh` | Ubuntu/Debian | Automates installation of system dependencies (build tools, Qt, OpenImageIO, Exiv2, etc.) with pinned versions |
| `setup/setup-macos.sh` | macOS | Automates installation via Homebrew with specific version constraints for Qt, Halide, OpenImageIO, etc. |

### 📚 Documentation Updates
- **`BUILDING_MAIN.md`**: Unified entry point; now references platform-specific guides and setup scripts
- **`BUILDING_LINUX.md`**: Updated to guide users through `setup-ubuntu.sh`; removed manual APT instructions
- **`BUILDING_MACOS.md`**: Updated to guide users through `setup-macos.sh`; removed manual Homebrew instructions
- **`BUILDING_WINDOWS.md`**: Clarified vcpkg workflow; aligned with main build guide
- **`INSTALLATION_HALIDE.md`** (renamed from `BUILDING_HALIDE.md`):
  - Reorganized into 3 clear methods: Pre-built Binary (🥇), Package Managers (🥈), Build from Source (🥉)
  - Added runtime dependency notes (copying `.dll`/`.so`/`.dylib` to build output)
  - Added CMake `-DHALIDE_DIR` usage example
- **`INSTALLATION_QT.md`** (new):
  - Dedicated guide for Qt 6.10.2 installation with `qtdeclarative` and `qtshadertools`
  - Covers both Qt Maintenance Tool and `aqtinstall` methods
  - Includes environment configuration (`CMAKE_PREFIX_PATH`) for Linux/macOS/Windows

### 🧹 Cleanup & Dependency Management
- **Docker (`docker/debian/Dockerfile`)**: Removed `libopencolorio-dev` ; OpenColorIO is now installed as part of OpenImageIO build
- **`setup-ubuntu.sh`**: Removed Halide installation (delegated to `INSTALLATION_HALIDE.md`); removed OpenColorIO (installed via OpenImageIO)
- **`setup-macos.sh`**: Uses specific version pins for critical dependencies to ensure reproducibility

## 🎯 Benefits

| Aspect | Improvement |
|--------|------------|
| **Onboarding** | New contributors can set up a working dev environment with a single script execution |
| **Consistency** | Pinned dependency versions reduce "works on my machine" issues across team members |
| **Maintainability** | Centralized setup logic in scripts; documentation focuses on guidance, not command lists |
| **Clarity** | Clear separation: `INSTALLATION_*.md` for dependency setup, `BUILDING_*.md` for project compilation |
| **Flexibility** | Users can still choose manual installation methods; scripts are optional helpers |

## 🧪 Testing Notes

- ✅ Verified `setup-ubuntu.sh` on fresh Ubuntu 22.04 Docker container
- ✅ Verified `setup-macos.sh` on macOS 14 (Sonoma) with clean Homebrew environment
- ✅ Confirmed CMake configuration succeeds post-setup on both platforms
- ✅ Validated that Halide pre-built binary method works with `-DHALIDE_DIR` override
- ✅ Ensured runtime library copying instructions are clear and tested

## 🔗 Related Documentation

- [BUILDING_MAIN.md](./docs/building/BUILDING_MAIN.md) – Unified build entry point
- [INSTALLATION_HALIDE.md](./docs/building/INSTALLATION_HALIDE.md) – Halide installation guide
- [INSTALLATION_QT.md](./docs/building/INSTALLATION_QT.md) – Qt installation guide
- [GENERAL_ARCHITECTURE.md](./docs/architecture/GENERAL_ARCHITECTURE.md) – Technical stack overview

---

*Branch*: `features/local_build`  
*Base*: `develop`  
*Author*: Yacine Benaffane