### PR TITLE
Fix/operations : Enforce Chunky-First Memory Layout & Optimize Halide Scheduling

### DIFF
--- a/core/include/pipeline/operations/operation_pipeline_executor.h
+++ b/core/include/pipeline/operations/operation_pipeline_executor.h
@@ -96,13 +96,13 @@ public:
 protected: 
      /**
      * @brief Applies scheduling directives (Vectorization/Parallelism/GPU tiling).
-     * @details  Called during the build phase to optimize `m_output_func`
+     * @details  Called during the build phase to optimize `output_func`
      * @param pipeline 
      * @param x 
-     * @param y 
-     * @param c 
+     * @param y
+     * @param c
      */
-    virtual void applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y) const = 0;
+    virtual void applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y, Halide::Var& c) const = 0;
     
     [[nodiscard]] bool executeOnHalideBuffer(Halide::Buffer<float>& input_buffer, Halide::Buffer<float>& output_buffer) override;
 

--- a/core/include/pipeline/operations/operation_pipeline_executor_cpu.h
+++ b/core/include/pipeline/operations/operation_pipeline_executor_cpu.h
@@ -36,7 +36,7 @@ public:
     [[nodiscard]] bool execute(ImageProcessing::IWorkingImageHardware& working_image) override;
 
 private:
-    void applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y) const override;
+    void applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y, Halide::Var& c) const override;
 };
 } // namespace Pipeline
 } // namespace CaptureMoment::Core

--- a/core/include/pipeline/operations/operation_pipeline_executor_gpu.h
+++ b/core/include/pipeline/operations/operation_pipeline_executor_gpu.h
@@ -36,7 +36,7 @@ public:
     [[nodiscard]] bool execute(ImageProcessing::IWorkingImageHardware& working_image) override;
 
 private:
-    void applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y) const override;
+    void applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y, Halide::Var& c) const override;
 };
 } // namespace Pipeline
 } // namespace CaptureMoment::Core

--- a/core/src/image_processing/cpu/working_image_cpu_halide.cpp
+++ b/core/src/image_processing/cpu/working_image_cpu_halide.cpp
@@ -32,11 +32,10 @@ bool WorkingImageCPU_Halide::bindView(const ImageView& view)
         return false;
     }
 
-    m_halide_original_buffer = Halide::Buffer<float>(
+    m_halide_original_buffer = Halide::Buffer<float>::make_interleaved(
         const_cast<float*>(m_view_data_image.original_data.data()),
         m_view_data_image.width, m_view_data_image.height, m_view_data_image.channels
         );
-
 
     spdlog::debug("[WorkingImageCPU_Halide::bindView]: Bound and initialized Halide ({}x{}, {} ch).",
                   m_view_data_image.width, m_view_data_image.height, m_view_data_image.channels);

--- a/core/src/image_processing/gpu/working_image_gpu_halide.cpp
+++ b/core/src/image_processing/gpu/working_image_gpu_halide.cpp
@@ -28,7 +28,7 @@ bool WorkingImageGPU_Halide::bindView(const ImageView& view)
         spdlog::error("[WorkingImageGPU_Halide::bindView]: Failed to init working buffer.");
         return false;
     }
-    m_original_halide_buffer = Halide::Buffer<float>(
+    m_original_halide_buffer = Halide::Buffer<float>::make_interleaved(
         const_cast<float*>(m_view_data_image.original_data.data()),
         m_view_data_image.width,
         m_view_data_image.height,
@@ -60,7 +60,10 @@ WorkingImageGPU_Halide::transferToVRAM()
 
         // Pipeline Reset
         Halide::Func reset_func("gpu_reset");
+
         reset_func(x, y, c) = m_original_halide_buffer(x, y, c);
+        reset_func.output_buffer().dim(0).set_stride(4);
+        reset_func.output_buffer().dim(2).set_stride(1);
         reset_func.compile_jit(target);
         m_reset_pipeline = Halide::Pipeline(reset_func);
 
@@ -155,12 +158,12 @@ WorkingImageGPU_Halide::downsample(Common::ImageDim target_width, Common::ImageD
         m_downsample_input.set(m_halide_buffer);
 
         std::vector<float> result_data(target_width * target_height * m_view_data_image.channels);
-        Halide::Buffer<float> dst_buffer(
+        Halide::Buffer<float> dst_buffer { Halide::Buffer<float>::make_interleaved(
             result_data.data(),
             static_cast<int>(target_width),
             static_cast<int>(target_height),
             static_cast<int>(m_view_data_image.channels)
-            );
+            )};
 
         m_downsample_scale_x.set(static_cast<float>(target_width) / m_view_data_image.width);
         m_downsample_scale_y.set(static_cast<float>(target_height) / m_view_data_image.height);
@@ -191,6 +194,9 @@ void WorkingImageGPU_Halide::buildDownsamplePipeline()
 {
     if (m_downsample_built) return;
 
+    m_downsample_input.dim(0).set_stride(4);
+    m_downsample_input.dim(2).set_stride(1);
+
     Halide::Var x, y, c, k;
     Halide::Func clamped{Halide::BoundaryConditions::repeat_edge(m_downsample_input)};
 
@@ -219,6 +225,9 @@ void WorkingImageGPU_Halide::buildDownsamplePipeline()
 
     Halide::Func final_output{"final_output"};
     final_output(x, y, c) = Halide::clamp(resized_x(x, y, c), 0.0f, 1.0f);
+
+    final_output.output_buffer().dim(0).set_stride(4);
+    final_output.output_buffer().dim(2).set_stride(1);
 
     Halide::Target target{Config::AppConfig::getHalideTarget()};
 

--- a/core/src/image_processing/halide/working_image_halide.cpp
+++ b/core/src/image_processing/halide/working_image_halide.cpp
@@ -19,7 +19,8 @@ void WorkingImageHalide::initializeHalide(std::span<float> data, Common::ImageDi
 
     // Create Halide Buffer View (Zero-Copy)
     // std::span::data() returns the underlying pointer safely.
-    m_halide_buffer = Halide::Buffer<float>(data.data(), width, height, channels);
+    // Transform from Chunky OIIO to Plannar Halide layout is handled by Halide::Buffer<float>::make_interleaved.
+    m_halide_buffer = Halide::Buffer<float>::make_interleaved(data.data(), width, height, channels);
 
     if (!m_halide_buffer.defined()) {
         spdlog::error("[WorkingImageHalide::initializeHalide]: Failed to define Halide::Buffer.");

--- a/core/src/pipeline/operations/operation_pipeline_executor.cpp
+++ b/core/src/pipeline/operations/operation_pipeline_executor.cpp
@@ -20,6 +20,9 @@ OperationPipelineExecutor::OperationPipelineExecutor()
       m_factory(nullptr),
       m_chain_built(false)
 {
+    m_input.dim(0).set_stride(4);
+    m_input.dim(2).set_stride(1);
+
     spdlog::debug("OperationPipelineExecutor: Constructed. Input set to Float(32), 3 dimensions. Backend: {}",
                   static_cast<int>(Config::AppConfig::instance().getProcessingBackend()));
 }
@@ -126,12 +129,14 @@ void OperationPipelineExecutor::buildOperationChain()
             spdlog::warn("OperationPipelineExecutor::buildOperationChain: Operation '{}' does not support fusion. Skipping.", desc.name);
         }
     }
+    output_func.output_buffer().dim(0).set_stride(4);
+    output_func.output_buffer().dim(2).set_stride(1);
 
     Halide::Target target { Config::AppConfig::getHalideTarget() };
     spdlog::info("OperationPipelineExecutor::buildOperationChain: Compiling for target: {}", target.to_string());
 
     // Apply scheduling (CPU or GPU)
-    applyScheduling(output_func, x, y);
+    applyScheduling(output_func, x, y, c);
 
     try {
         // Compile JIT with the GPU target (e.g., Vulkan)

--- a/core/src/pipeline/operations/operation_pipeline_executor_cpu.cpp
+++ b/core/src/pipeline/operations/operation_pipeline_executor_cpu.cpp
@@ -12,10 +12,10 @@
 
 namespace CaptureMoment::Core::Pipeline {
 
-void OperationPipelineExecutorCPU::applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y) const
+void OperationPipelineExecutorCPU::applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y, Halide::Var& c) const
 {
     Halide::Var yo, yi;
-    pipeline.split(y, yo, yi, 32).parallel(yo).vectorize(x, 8);
+    pipeline.bound(c, 0, 4).reorder(c, x, y).split(y, yo, yi, 32).parallel(yo).unroll(c);
     spdlog::trace("OperationPipelineExecutorCPU::applyScheduling: Applying CPU scheduling.");
 }
 

--- a/core/src/pipeline/operations/operation_pipeline_executor_gpu.cpp
+++ b/core/src/pipeline/operations/operation_pipeline_executor_gpu.cpp
@@ -12,7 +12,7 @@
 
 namespace CaptureMoment::Core::Pipeline {
 
-void OperationPipelineExecutorGPU::applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y) const
+void OperationPipelineExecutorGPU::applyScheduling(Halide::Func& pipeline, Halide::Var& x, Halide::Var& y, Halide::Var &c) const
 {
     Halide::Var xo, yo, xi, yi;
     pipeline.gpu_tile(x, y, xo, yo, xi, yi, 16, 16);

--- a/docs/architecture/CORE_DESIGN.md
+++ b/docs/architecture/CORE_DESIGN.md
@@ -399,3 +399,16 @@ This interface represents an image used as a working buffer, abstracting its har
 * **`CaptureMoment::Core::utils::toString`**: A generic template function using C++20 Concepts (`ToStringablePrimitive`) for converting primitive types (int, float, double, bool) and strings to their string representation.
 
 * **Usage:** Replaces legacy specific functions like `serializeFloat`, `serializeDouble`, etc., within the serialization module and other parts of the core requiring type-to-string conversion.
+
+## 15. Halide Pipeline Architecture: Chunky-First Paradigm
+
+* **Problem:** Traditional Halide pipelines assume a Planar memory layout (Stride X=1), which requires expensive Chunky↔Planar conversions when interfacing with display APIs and OIIO-decoded images.
+* **Solution:** Enforce a strict Interleaved (Chunky) memory layout [R0,G0,B0,A0, R1,G1,B1,A1...] from decode to display, eliminating conversion overhead.
+* [🟦 **SEE IMAGE PIPELINE.md.md**](core/IMAGE_PIPELINE.md).
+
+## 16. Other docs:
+* [🟦 **SEE IMAGE PROCESSING.md**](core/IMAGE_PROCESSING.md).
+* [🟦 **SEE IMAGE PIPELINE.md.md**](core/IMAGE_PIPELINE.md).
+* [🟦 **SEE OPERATIONS.md**](core/OPERATIONS.md).
+* [🟦 **SEE SERIALIZER.md**](core/SERIALIZER.md).
+

--- a/docs/architecture/core/IMAGE_PIPELINE.md
+++ b/docs/architecture/core/IMAGE_PIPELINE.md
@@ -1,0 +1,89 @@
+# 🧠 Halide Pipeline Architecture: The Chunky-First Paradigm
+
+## Overview
+
+The Halide execution pipeline in CaptureMoment is built around a strict, zero-copy philosophy. Instead of treating memory layout conversions as a necessary evil, the pipeline enforces an Interleaved (Chunky) memory layout from the moment the image is decoded until it is rendered on screen.
+
+This decision fundamentally shapes how the Halide Abstract Syntax Tree (AST) is scheduled for both CPU and GPU targets, requiring explicit stride constraints and specific loop reorderings to maintain high performance without ever copying or shuffling pixel data.The Halide execution pipeline in CaptureMoment is built around a strict, zero-copy philosophy. Instead of treating memory layout conversions as a necessary evil, the pipeline enforces an Interleaved (Chunky) memory layout from the moment the image is decoded until it is rendered on screen.
+
+This decision fundamentally shapes how the Halide Abstract Syntax Tree (AST) is scheduled for both CPU and GPU targets, requiring explicit stride constraints and specific loop reorderings to maintain high performance without ever copying or shuffling pixel data.
+
+---
+
+## The Memory Layout Dilemma: Chunky vs. Planar
+To understand the pipeline architecture, one must understand the two primary ways to store multi-channel images in memory:
+
+* **Planar (Separated):** [R0, R1, R2... G0, G1, G2... B0, B1, B2...]
+* Pros: Trivial vectorization for single-channel algorithms (e.g., blurring only the Red channel). This is the default assumption of the Halide scheduling API.
+* Cons: Requires explicit conversion to be displayed.
+
+* **Chunky (Interleaved):** [R0, G0, B0, A0, R1, G1, B1, A1...]
+* Pros: Native format for display APIs (OpenGL, Vulkan, QML).
+* Cons: Harder to vectorize naively if the scheduler treats dimensions independently.
+
+### The Architectural Decision: Why Chunky-First?
+
+In a real-time photo editing UI, memory bandwidth and PCIe transfers are critical bottlenecks. Every time an image is zoomed, panned, or a slider is adjusted, a downscaled preview must be generated and pushed to the GPU for rendering.
+
+If we used Planar memory for processing, the pipeline would look like this:
+
+1. Decode JPEG to Chunky.
+2. Convert to Planar (Expensive CPU cache-miss intensive loop).
+3. Execute Halide algorithm.
+4. Convert back to Chunky (Another expensive loop).
+5. Upload to GPU for display.
+
+By enforcing a Chunky-First pipeline, we eliminate steps 2 and 4. The Halide pipeline reads the Chunky buffer directly, modifies it, and the result is instantly ready for the UI thread. Even as the pipeline evolves to include heavier computational algorithms (such as complex color space transformations, advanced noise reduction, or OpenCV integration), avoiding these continuous memory channel shuffles for UI feedback remains a massive net gain for responsiveness.
+
+---
+
+## Enforcing Chunky in Halide: The Technical Implementation
+By default, Halide's scheduling API assumes a Planar layout (Stride X = 1). To force the compiler to generate correct machine code for Chunky data, a three-layer constraint system is applied to every pipeline graph.
+
+### 1. The Physical Buffer (C++ API)
+When wrapping the `std::span<float>` from the source manager, we do not use the default Halide buffer constructor. We use:
+
+`Halide::Buffer<float>::make_interleaved(data_ptr, width, height, channels)`;
+This configures the physical memory strides (X=4, Y=Width*4, C=1) without allocating or moving a single byte.
+
+```cpp
+m_input.dim(0).set_stride(4); 
+m_input.dim(2).set_stride(1);
+```
+
+### 3. The Output Contract (OutputImageParam)
+This is the most critical and easily missed step. Even though a `Halide::Func` is a pure mathematical object, its output realization has an implicit constraint (Stride X = 1). If not explicitly overridden, Halide will crash at runtime (`Constraint violated`) when the provided output buffer is Chunky.
+
+```cpp
+output_func.output_buffer().dim(0).set_stride(4);
+output_func.output_buffer().dim(2).set_stride(1);
+```
+
+---
+
+## Scheduling Strategies for Chunky Data
+Because the memory layout is Chunky, the default Halide schedules (which vectorize over X) are highly suboptimal or simply crash. The scheduling must be explicitly adapted for the interleaved strides.
+
+### CPU Scheduling: Contiguous Vectorization
+The default loop order `Y -> X -> C` is disastrous for Chunky data on a CPU. When the inner loop is over `X`, the CPU tries to load `R0`, but the next pixel `R1` is 4 bytes away. This forces LLVM to generate expensive "Gather" instructions instead of fast contiguous "Load" instructions.
+
+We solve this by forcing the channel `C` to be the innermost loop, matching the physical memory layout:
+
+```cpp
+pipeline.bound(c, 0, 4)       // Guarantee exactly 4 channels (RGBA)
+         .reorder(c, x, y)    // Loop order is now Y -> X -> C
+         .split(y, yo, yi, 32)
+         .parallel(yo)
+         .unroll(c);           // Unroll R, G, B, A
+```
+### GPU Scheduling: Thread-Level Constraints
+On the GPU, `gpu_tile(x, y, ...)` maps `x` and `y` to GPU threads. We cannot reorder c outside the thread bounds without breaking the parallelism.
+
+Instead, the absolute priority is satisfying the stride constraints. If the GPU backend attempts to vectorize the `x` dimension natively and encounters a stride of 4, it will attempt an unsupported scatter/gather operation, resulting in a silent driver crash (SIGABRT).
+
+The solution is to leave the channel loop implicit inside the GPU threads, relying purely on the stride constraints to guide the backend compiler (CUDA/Vulkan) to generate correct memory access patterns for the `RGBA` layout without crashing.
+
+```cpp
+// No reorder on GPU. Just strict stride constraints + tiling.
+pipeline.gpu_tile(x, y, xo, yo, xi, yi, 16, 16);
+```


### PR DESCRIPTION
This PR enforces a strict **Interleaved (Chunky)** memory layout `[R0,G0,B0,A0, R1,G1,B1,A1...]` throughout the Halide processing pipeline, eliminating costly Planar↔Chunky conversions. It adds explicit stride constraints, optimizes CPU scheduling for interleaved data, and introduces comprehensive documentation for the new paradigm.

## 🔑 Key Changes

### 🧱 Chunky-First Memory Layout
| File | Change | Impact |
|------|--------|--------|
| `working_image_halide.cpp` | `Halide::Buffer<float>::make_interleaved()` instead of default constructor | Configures physical strides (X=4, C=1) without copying data |
| `working_image_cpu_halide.cpp` | Same `make_interleaved()` usage for original buffer | Ensures consistent layout for non-destructive pipeline input |
| `working_image_gpu_halide.cpp` | `make_interleaved()` + explicit strides on `reset_func`, `final_output`, `dst_buffer` | Prevents GPU driver crashes from invalid scatter/gather access |

### ⚙️ Explicit Stride Constraints
- **Input/Output Buffers**: Added `dim(0).set_stride(4); dim(2).set_stride(1);` to `m_input`, `output_func.output_buffer()`, and intermediate Halide funcs.
- **Purpose**: Prevents runtime `Constraint violated` errors when Halide's default Planar assumption (Stride X=1) conflicts with actual Chunky memory layout.

### 🚀 CPU Scheduling Optimization
- **File**: `operation_pipeline_executor_cpu.cpp`
- **New Schedule**:
  ```cpp
  pipeline.bound(c, 0, 4)       // Guarantee exactly 4 channels (RGBA)
           .reorder(c, x, y)    // Loop order: Y → X → C (matches memory layout)
           .split(y, yo, yi, 32)
           .parallel(yo)
           .unroll(c);          // Unroll R,G,B,A for SIMD-friendly vectorization

## 📚 Documentation
* **New File:** `docs/architecture/core/IMAGE_PIPELINE.md`
- Explains Chunky vs Planar memory layouts
- Details the three-layer constraint system (physical buffer, input binding, output contract)
- Documents CPU/GPU scheduling strategies for interleaved data
* **Updated:** `CORE_DESIGN.md` – Added Section IMAGE_PIPELINE.md` and summarizing the Chunky-First paradigm.